### PR TITLE
Phases 5–6: videos, favorites page, and setlist detail

### DIFF
--- a/app/(dashboard)/favorites/page.tsx
+++ b/app/(dashboard)/favorites/page.tsx
@@ -1,0 +1,56 @@
+import { getFavoriteTabsForUser } from "@/lib/api";
+import { Badge } from "@/components/ui/badge";
+import { createClient } from "@/utils/supabase/server";
+import Link from "next/link";
+
+export default async function FavoritesPage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return (
+      <div className="container py-10">
+        <h1 className="text-3xl font-bold mb-6">Favorites</h1>
+        <p className="text-muted-foreground">
+          Sign in to see your favorite tabs.
+        </p>
+      </div>
+    );
+  }
+
+  const tabs = await getFavoriteTabsForUser();
+
+  return (
+    <div className="container py-10">
+      <h1 className="text-3xl font-bold mb-6">Favorites</h1>
+
+      {tabs.length === 0 ? (
+        <p className="text-muted-foreground">
+          You haven&apos;t favorited any tabs yet.
+        </p>
+      ) : (
+        <div className="grid gap-4">
+          {tabs.map((tab) => (
+            <Link
+              key={tab.id}
+              href={`/songs/${tab.song.slug}`}
+              className="p-4 rounded-lg border hover:border-primary transition-colors"
+            >
+              <div className="flex items-center justify-between">
+                <div>
+                  <h3 className="text-lg font-semibold">{tab.song.song}</h3>
+                  <p className="text-sm text-muted-foreground">
+                    by {tab.user?.username ?? "Unknown"}
+                  </p>
+                </div>
+                <Badge variant="secondary">{tab.type}</Badge>
+              </div>
+            </Link>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/(dashboard)/setlists/[id]/page.tsx
+++ b/app/(dashboard)/setlists/[id]/page.tsx
@@ -1,0 +1,69 @@
+import { getSetlistById } from "@/lib/api";
+import { DeleteSetlistButton } from "@/components/delete-setlist-button";
+import { Button } from "@/components/ui/button";
+import { createClient } from "@/utils/supabase/server";
+import Link from "next/link";
+
+export default async function SetlistPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const setlist = await getSetlistById(id);
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  const isOwner = !!user && user.id === setlist.creator_id;
+
+  return (
+    <div className="container py-10">
+      <div className="max-w-2xl mx-auto">
+        <div className="flex items-start justify-between mb-6">
+          <div>
+            <h1 className="text-3xl font-bold">{setlist.name}</h1>
+            {setlist.venue && (
+              <p className="text-muted-foreground">{setlist.venue}</p>
+            )}
+            {setlist.date && (
+              <p className="text-sm text-muted-foreground">
+                {new Date(setlist.date).toLocaleDateString()}
+              </p>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button asChild variant="ghost" size="sm">
+              <Link href="/setlists">Back</Link>
+            </Button>
+            {isOwner && <DeleteSetlistButton setlistId={setlist.id} />}
+          </div>
+        </div>
+
+        {setlist.setlist_songs.length === 0 ? (
+          <p className="text-muted-foreground">This setlist has no songs.</p>
+        ) : (
+          <ol className="space-y-2">
+            {setlist.setlist_songs.map((entry, index) => (
+              <li
+                key={entry.songs.id}
+                className="flex items-center gap-3 p-3 rounded-lg border"
+              >
+                <span className="text-sm text-muted-foreground w-6">
+                  {index + 1}.
+                </span>
+                <Link
+                  href={`/songs/${entry.songs.slug}`}
+                  className="hover:underline"
+                >
+                  {entry.songs.song}
+                </Link>
+              </li>
+            ))}
+          </ol>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/songs/[slug]/page.tsx
+++ b/app/(dashboard)/songs/[slug]/page.tsx
@@ -8,7 +8,11 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { TabSection } from "@/components/tab-section";
 import { AddTabDialog } from "@/components/add-tab-dialog";
+import { AddVideoDialog } from "@/components/add-video-dialog";
+import { DeleteVideoButton } from "@/components/delete-video-button";
+import { VideoEmbed } from "@/components/video-embed";
 import { Discussion } from "@/components/discussion";
+import { Badge } from "@/components/ui/badge";
 import { createClient } from "@/utils/supabase/server";
 
 export default async function SongPage({
@@ -67,9 +71,44 @@ export default async function SongPage({
           />
         </TabsContent>
         <TabsContent value="videos">
-          <h2 className="text-2xl font-semibold mb-4">Videos</h2>
-          {videos.length === 0 && (
+          {isAuthed && (
+            <div className="flex justify-end mb-4">
+              <AddVideoDialog songId={song.id} slug={slug} />
+            </div>
+          )}
+          {videos.length === 0 ? (
             <p className="text-muted-foreground">No videos yet.</p>
+          ) : (
+            <div className="grid gap-6 sm:grid-cols-2">
+              {videos.map((video) => (
+                <div key={video.id} className="space-y-2">
+                  <VideoEmbed
+                    platform={video.platform}
+                    videoId={video.video_id}
+                    title={video.name}
+                  />
+                  <div className="flex items-center justify-between gap-2">
+                    <div>
+                      <p className="font-medium">{video.name}</p>
+                      <Badge variant="secondary" className="mt-1">
+                        {video.type}
+                      </Badge>
+                    </div>
+                    {user && video.created_by === user.id && (
+                      <DeleteVideoButton
+                        videoId={video.id}
+                        revalidate={revalidatePath}
+                      />
+                    )}
+                  </div>
+                  {video.description && (
+                    <p className="text-sm text-muted-foreground">
+                      {video.description}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
           )}
         </TabsContent>
         <TabsContent value="lyrics">

--- a/app/(dashboard)/videos/page.tsx
+++ b/app/(dashboard)/videos/page.tsx
@@ -1,0 +1,40 @@
+import { getRecentVideos } from "@/lib/api";
+import { VideoEmbed } from "@/components/video-embed";
+import { Badge } from "@/components/ui/badge";
+import Link from "next/link";
+
+export default async function VideosPage() {
+  const videos = await getRecentVideos();
+
+  return (
+    <div className="container py-10">
+      <h1 className="text-3xl font-bold mb-6">Videos</h1>
+
+      {videos.length === 0 ? (
+        <p className="text-muted-foreground">No videos have been added yet.</p>
+      ) : (
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {videos.map((video) => (
+            <div key={video.id} className="space-y-2">
+              <VideoEmbed
+                platform={video.platform}
+                videoId={video.video_id}
+                title={video.name}
+              />
+              <div className="flex items-center justify-between gap-2">
+                <p className="font-medium">{video.name}</p>
+                <Badge variant="secondary">{video.type}</Badge>
+              </div>
+              <Link
+                href={`/songs/${video.song.slug}`}
+                className="text-sm text-muted-foreground hover:underline"
+              >
+                {video.song.song}
+              </Link>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -289,3 +289,108 @@ export async function createSetlist(formData: FormData) {
 
   revalidatePath("/setlists");
 }
+
+export async function deleteSetlist(id: string) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const { error } = await supabase
+    .from("setlists")
+    .delete()
+    .eq("id", id)
+    .eq("creator_id", user.id);
+
+  if (error) throw error;
+
+  revalidatePath("/setlists");
+  redirect("/setlists");
+}
+
+// Extract the platform + video id from a YouTube or Vimeo URL.
+function parseVideoUrl(
+  url: string
+): { platform: "youtube" | "vimeo"; videoId: string } | null {
+  try {
+    const u = new URL(url.trim());
+    const host = u.hostname.replace(/^www\./, "");
+    if (host === "youtu.be") {
+      const id = u.pathname.slice(1);
+      return id ? { platform: "youtube", videoId: id } : null;
+    }
+    if (host.endsWith("youtube.com")) {
+      const v = u.searchParams.get("v");
+      if (v) return { platform: "youtube", videoId: v };
+      const parts = u.pathname.split("/").filter(Boolean);
+      const idx = parts.findIndex((p) => p === "embed" || p === "shorts");
+      if (idx >= 0 && parts[idx + 1]) {
+        return { platform: "youtube", videoId: parts[idx + 1] };
+      }
+    }
+    if (host.endsWith("vimeo.com")) {
+      const id = u.pathname.split("/").filter(Boolean).pop();
+      if (id && /^\d+$/.test(id)) return { platform: "vimeo", videoId: id };
+    }
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+export async function createVideo(formData: FormData) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const songId = formData.get("songId") as string;
+  const slug = formData.get("slug") as string;
+  const url = formData.get("url") as string;
+  const type = formData.get("type") as string;
+  const name = (formData.get("name") as string)?.trim();
+  const description = (formData.get("description") as string)?.trim();
+
+  if (!name) throw new Error("Name is required");
+  const parsed = parseVideoUrl(url ?? "");
+  if (!parsed) throw new Error("Unsupported video URL (YouTube or Vimeo only)");
+
+  const { error } = await supabase.from("videos").insert({
+    song_id: songId,
+    type,
+    platform: parsed.platform,
+    video_id: parsed.videoId,
+    name,
+    description: description || null,
+    created_by: user.id,
+  });
+
+  if (error) throw error;
+
+  if (slug) revalidatePath(`/songs/${slug}`);
+  revalidatePath("/videos");
+}
+
+export async function deleteVideo(videoId: string, revalidate?: string) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  const { error } = await supabase
+    .from("videos")
+    .delete()
+    .eq("id", videoId)
+    .eq("created_by", user.id);
+
+  if (error) throw error;
+
+  if (revalidate) revalidatePath(revalidate);
+  revalidatePath("/videos");
+}

--- a/components/add-video-dialog.tsx
+++ b/components/add-video-dialog.tsx
@@ -1,0 +1,81 @@
+"use client";
+import * as React from "react";
+import { createVideo } from "@/app/actions";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { Plus } from "lucide-react";
+
+export function AddVideoDialog({
+  songId,
+  slug,
+}: {
+  songId: string;
+  slug: string;
+}) {
+  const [open, setOpen] = React.useState(false);
+
+  async function action(formData: FormData) {
+    await createVideo(formData);
+    setOpen(false);
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <DialogTrigger asChild>
+        <Button size="sm">
+          <Plus className="h-4 w-4 mr-1" /> Add video
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Add a video</DialogTitle>
+        </DialogHeader>
+        <form action={action} className="space-y-4">
+          <input type="hidden" name="songId" value={songId} />
+          <input type="hidden" name="slug" value={slug} />
+          <div className="space-y-2">
+            <Label htmlFor="url">YouTube or Vimeo URL</Label>
+            <Input
+              id="url"
+              name="url"
+              required
+              placeholder="https://www.youtube.com/watch?v=..."
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="name">Title</Label>
+            <Input id="name" name="name" required placeholder="e.g. Solo lesson" />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="video-type">Type</Label>
+            <select
+              id="video-type"
+              name="type"
+              defaultValue="lesson"
+              className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+            >
+              <option value="lesson">Lesson</option>
+              <option value="performance">Performance</option>
+            </select>
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="description">Description (optional)</Label>
+            <Textarea id="description" name="description" rows={3} />
+          </div>
+          <div className="flex justify-end">
+            <Button type="submit">Save video</Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/components/delete-setlist-button.tsx
+++ b/components/delete-setlist-button.tsx
@@ -1,0 +1,26 @@
+"use client";
+import * as React from "react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { deleteSetlist } from "@/app/actions";
+
+export function DeleteSetlistButton({ setlistId }: { setlistId: string }) {
+  const [pending, startTransition] = React.useTransition();
+
+  return (
+    <Button
+      type="button"
+      variant="outline"
+      size="sm"
+      disabled={pending}
+      onClick={() => {
+        if (!confirm("Delete this setlist?")) return;
+        startTransition(async () => {
+          await deleteSetlist(setlistId);
+        });
+      }}
+    >
+      <Trash2 className="h-4 w-4 mr-1" /> Delete
+    </Button>
+  );
+}

--- a/components/delete-video-button.tsx
+++ b/components/delete-video-button.tsx
@@ -1,0 +1,32 @@
+"use client";
+import * as React from "react";
+import { Trash2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { deleteVideo } from "@/app/actions";
+
+export function DeleteVideoButton({
+  videoId,
+  revalidate,
+}: {
+  videoId: string;
+  revalidate?: string;
+}) {
+  const [pending, startTransition] = React.useTransition();
+
+  return (
+    <Button
+      type="button"
+      variant="ghost"
+      size="sm"
+      disabled={pending}
+      onClick={() => {
+        if (!confirm("Delete this video?")) return;
+        startTransition(async () => {
+          await deleteVideo(videoId, revalidate);
+        });
+      }}
+    >
+      <Trash2 className="h-4 w-4" />
+    </Button>
+  );
+}

--- a/components/video-embed.tsx
+++ b/components/video-embed.tsx
@@ -1,0 +1,28 @@
+import { VideoPlatform } from "@/types";
+
+export function VideoEmbed({
+  platform,
+  videoId,
+  title,
+}: {
+  platform: VideoPlatform;
+  videoId: string;
+  title: string;
+}) {
+  const src =
+    platform === "youtube"
+      ? `https://www.youtube.com/embed/${videoId}`
+      : `https://player.vimeo.com/video/${videoId}`;
+
+  return (
+    <div className="aspect-video w-full overflow-hidden rounded-lg border">
+      <iframe
+        src={src}
+        title={title}
+        className="h-full w-full"
+        allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+        allowFullScreen
+      />
+    </div>
+  );
+}

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -69,8 +69,8 @@ Real defects in scaffolded code, not new features.
     (insert/delete on `favorites`). DELETE RLS policy already existed.
 12. **Real `userFavoriteTabIds`** ✅ — `getUserFavoriteTabIds()` feeds the song
     page; `FavoriteButton` does an optimistic toggle on the selected tab.
-13. **`/favorites` page** — list the signed-in user's favorited tabs; not done
-    yet.
+13. **`/favorites` page** ✅ — lists the signed-in user's favorited tabs via
+    `getFavoriteTabsForUser()`.
 
 ## Phase 4 — Discussion / comments ✅ (done)
 
@@ -80,20 +80,22 @@ Real defects in scaffolded code, not new features.
     profiles in code (no FK to embed); `Discussion` renders authors, one level
     of nested replies, and per-comment reply forms.
 
-## Phase 5 — Videos
+## Phase 5 — Videos ✅ (done)
 
-16. **Render videos** — `getVideosBySongId` is fetched but the Videos tab is an
-    empty `<h2>`. Build a YouTube/Vimeo embed component; split lessons vs.
-    performances.
-17. **Video submission** — add a creator/owner column via migration (the table
-    comment flags this), an action, and UI. `/videos` index page.
+16. **Render videos** ✅ — `VideoEmbed` (YouTube/Vimeo iframe) on the song
+    page Videos tab, with type badges and descriptions.
+17. **Video submission** ✅ — migration `20260606215653_add_created_by_to_videos`
+    adds an owner column + owner-delete RLS policy; `createVideo`/`deleteVideo`
+    actions (URL is parsed to platform + id); `AddVideoDialog`,
+    `DeleteVideoButton`, and a `/videos` index page.
 
-## Phase 6 — Setlists completion
+## Phase 6 — Setlists completion (partial)
 
-18. **`/setlists/[id]` detail page** — `getSetlistById` exists; the list links
-    here but the route doesn't. Build it (ordered songs).
-19. **Edit / delete / reorder** — owner mutations + DELETE RLS; drag-to-reorder
-    against the `position` column.
+18. **`/setlists/[id]` detail page** ✅ — ordered songs via `getSetlistById`
+    (now left-joined so empty setlists resolve), with an owner-only delete
+    (`deleteSetlist`).
+19. **Edit / reorder** — drag-to-reorder against the `position` column and
+    editing setlist metadata are still **not done**.
 
 ## Phase 7 — Profiles & auth polish
 

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -50,23 +50,33 @@ export async function getSetlists(limit = 10) {
   return setlists as Setlist[];
 }
 
-export async function getSetlistById(id: string) {
+export type SetlistWithSongs = Setlist & {
+  setlist_songs: Array<{ position: number; songs: Song }>;
+};
+
+export async function getSetlistById(id: string): Promise<SetlistWithSongs> {
   const supabase = await createClient();
+  // Left joins so setlists with no songs still resolve.
   const { data: setlist, error } = await supabase
     .from("setlists")
     .select(
       `
       *,
-      setlist_songs!inner (
-        *,
-        songs!inner (*)
+      setlist_songs (
+        position,
+        songs (*)
       )
     `
     )
     .eq("id", id)
     .single();
   if (error) throw error;
-  return setlist as Setlist & { setlist_songs: Array<{ songs: Song }> };
+
+  const result = setlist as SetlistWithSongs;
+  result.setlist_songs = (result.setlist_songs ?? []).sort(
+    (a, b) => a.position - b.position
+  );
+  return result;
 }
 
 export async function searchSongs(query: string) {
@@ -204,4 +214,53 @@ export async function getVideosBySongId(songId: string) {
     .order("created_at", { ascending: false });
   if (error) throw error;
   return videos as Video[];
+}
+
+export type RecentVideo = Video & { song: { song: string; slug: string } };
+
+export async function getRecentVideos(limit = 50): Promise<RecentVideo[]> {
+  const supabase = await createClient();
+  const { data, error } = await supabase
+    .from("videos")
+    .select(
+      `
+      *,
+      song:songs!song_id (song, slug)
+    `
+    )
+    .order("created_at", { ascending: false })
+    .limit(limit);
+  if (error) throw error;
+  return (data ?? []) as unknown as RecentVideo[];
+}
+
+export type FavoriteTab = Tab & { song: { song: string; slug: string } };
+
+export async function getFavoriteTabsForUser(): Promise<FavoriteTab[]> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return [];
+
+  const { data, error } = await supabase
+    .from("favorites")
+    .select(
+      `
+      created_at,
+      tab:tabs!tab_id (
+        *,
+        song:songs!song_id (song, slug),
+        user:profiles!author_id (username, avatar_url)
+      )
+    `
+    )
+    .eq("user_id", user.id)
+    .not("tab_id", "is", null)
+    .order("created_at", { ascending: false });
+  if (error) throw error;
+
+  return (data ?? [])
+    .map((row: any) => row.tab)
+    .filter(Boolean) as FavoriteTab[];
 }

--- a/supabase/migrations/20260606215653_add_created_by_to_videos.sql
+++ b/supabase/migrations/20260606215653_add_created_by_to_videos.sql
@@ -1,0 +1,6 @@
+-- Track who submitted a video so submitters can delete their own.
+alter table videos
+  add column if not exists created_by uuid references auth.users(id) on delete set null;
+
+create policy "Video owners can delete their videos" on videos
+  for delete using (auth.uid() = created_by);

--- a/types/index.ts
+++ b/types/index.ts
@@ -73,6 +73,7 @@ export interface Video {
   video_id: string;
   name: string;
   description: string | null;
+  created_by?: string | null;
   created_at: string;
   updated_at: string;
 }


### PR DESCRIPTION
Continues the roadmap with media, the favorites view, and setlist detail. Together these remove the last sidebar 404s (`/videos`, `/favorites`) and the broken `/setlists/[id]` links.

## Phase 5 — Videos
- Migration `20260606215653_add_created_by_to_videos`: adds an owner column + an owner-delete RLS policy (**applied to the live DB**).
- `createVideo` (parses YouTube/Vimeo URLs to platform + video id) and `deleteVideo` server actions.
- `VideoEmbed` component (responsive iframe); the song page Videos tab now renders embeds with type badges + descriptions, an auth-gated `AddVideoDialog`, and an owner-only `DeleteVideoButton`.
- New `/videos` index page.

## Phase 6 — Setlists (partial)
- New `/setlists/[id]` detail page: ordered songs (linked to song pages) with an owner-only delete.
- `deleteSetlist` server action (creator-scoped).
- `getSetlistById` switched to left joins + position sort so setlists with no songs still resolve (the previous `!inner` joins would 500 on an empty setlist).
- Still deferred: drag-to-reorder and editing setlist metadata.

## Also
- `/favorites` page (the deferred Phase 3 item) via `getFavoriteTabsForUser()`.
- Added `created_by` to the `Video` type.

## Verification
- `tsc --noEmit` clean; `next build` compiles all routes (`/videos`, `/favorites`, `/setlists/[id]` present) and prerenders with env vars present.
- Migration applied via MCP; local migration history matches the remote DB.

## Notes
- The live DB still has **0 songs** — run `scripts/syncSongs.ts` to populate the catalog (Phase 9) so these pages have content.

https://claude.ai/code/session_014L7KLJgiNNst5YbYrhGfqo

---
_Generated by [Claude Code](https://claude.ai/code/session_014L7KLJgiNNst5YbYrhGfqo)_