### PR TITLE
Modern, performance-focused UX for tabs, chords, and setlists

### DIFF
--- a/app/(dashboard)/setlists/[id]/page.tsx
+++ b/app/(dashboard)/setlists/[id]/page.tsx
@@ -2,6 +2,7 @@ import { getSetlistById } from "@/lib/api";
 import { DeleteSetlistButton } from "@/components/delete-setlist-button";
 import { Button } from "@/components/ui/button";
 import { createClient } from "@/utils/supabase/server";
+import { ArrowLeft, Music, Play } from "lucide-react";
 import Link from "next/link";
 
 export default async function SetlistPage({
@@ -17,45 +18,60 @@ export default async function SetlistPage({
     data: { user },
   } = await supabase.auth.getUser();
   const isOwner = !!user && user.id === setlist.creator_id;
+  const songCount = setlist.setlist_songs.length;
 
   return (
     <div className="container py-10">
       <div className="max-w-2xl mx-auto">
-        <div className="flex items-start justify-between mb-6">
+        <Button asChild variant="ghost" size="sm" className="mb-4 -ml-2">
+          <Link href="/setlists">
+            <ArrowLeft className="mr-1 h-4 w-4" /> All setlists
+          </Link>
+        </Button>
+
+        <div className="mb-6 flex flex-wrap items-start justify-between gap-3">
           <div>
             <h1 className="text-3xl font-bold">{setlist.name}</h1>
             {setlist.venue && (
               <p className="text-muted-foreground">{setlist.venue}</p>
             )}
-            {setlist.date && (
-              <p className="text-sm text-muted-foreground">
-                {new Date(setlist.date).toLocaleDateString()}
-              </p>
-            )}
+            <p className="mt-1 flex items-center gap-3 text-sm text-muted-foreground">
+              {setlist.date && (
+                <span>{new Date(setlist.date).toLocaleDateString()}</span>
+              )}
+              <span className="flex items-center gap-1">
+                <Music className="h-3.5 w-3.5" />
+                {songCount} song{songCount === 1 ? "" : "s"}
+              </span>
+            </p>
           </div>
           <div className="flex gap-2">
-            <Button asChild variant="ghost" size="sm">
-              <Link href="/setlists">Back</Link>
-            </Button>
+            {songCount > 0 && (
+              <Button asChild>
+                <Link href={`/setlists/${id}/perform`}>
+                  <Play className="mr-1 h-4 w-4" /> Perform
+                </Link>
+              </Button>
+            )}
             {isOwner && <DeleteSetlistButton setlistId={setlist.id} />}
           </div>
         </div>
 
-        {setlist.setlist_songs.length === 0 ? (
+        {songCount === 0 ? (
           <p className="text-muted-foreground">This setlist has no songs.</p>
         ) : (
           <ol className="space-y-2">
             {setlist.setlist_songs.map((entry, index) => (
               <li
                 key={entry.songs.id}
-                className="flex items-center gap-3 p-3 rounded-lg border"
+                className="flex items-center gap-3 rounded-lg border p-3 transition-colors hover:border-primary"
               >
-                <span className="text-sm text-muted-foreground w-6">
+                <span className="w-6 text-sm tabular-nums text-muted-foreground">
                   {index + 1}.
                 </span>
                 <Link
                   href={`/songs/${entry.songs.slug}`}
-                  className="hover:underline"
+                  className="font-medium hover:underline"
                 >
                   {entry.songs.song}
                 </Link>

--- a/app/(dashboard)/setlists/[id]/perform/page.tsx
+++ b/app/(dashboard)/setlists/[id]/perform/page.tsx
@@ -1,0 +1,19 @@
+import { getSetlistPerformanceData } from "@/lib/api";
+import { SetlistPerformer } from "@/components/setlist-performer";
+
+export default async function PerformSetlistPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  const { id } = await params;
+  const { setlist, songs } = await getSetlistPerformanceData(id);
+
+  return (
+    <SetlistPerformer
+      name={setlist.name}
+      songs={songs}
+      backHref={`/setlists/${id}`}
+    />
+  );
+}

--- a/app/(dashboard)/setlists/new/page.tsx
+++ b/app/(dashboard)/setlists/new/page.tsx
@@ -2,16 +2,21 @@ import { createSetlist } from "@/app/actions";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import { SetlistBuilder } from "@/components/setlist-builder";
 import { getSongs } from "@/lib/api";
 import Link from "next/link";
 
 export default async function NewSetlistPage() {
   const songs = await getSongs();
+  const options = songs.map((s) => ({ id: s.id, song: s.song }));
 
   return (
     <div className="container py-10">
       <div className="max-w-2xl mx-auto">
-        <h1 className="text-3xl font-bold mb-8">Create New Setlist</h1>
+        <h1 className="text-3xl font-bold mb-2">Create a setlist</h1>
+        <p className="text-muted-foreground mb-8">
+          Build an ordered set you can play hands-free in performance mode.
+        </p>
 
         <form action={createSetlist} className="space-y-6">
           <div className="space-y-2">
@@ -24,47 +29,28 @@ export default async function NewSetlistPage() {
             />
           </div>
 
-          <div className="space-y-2">
-            <Label htmlFor="date">Date</Label>
-            <Input id="date" name="date" type="date" />
-          </div>
-
-          <div className="space-y-2">
-            <Label htmlFor="venue">Venue</Label>
-            <Input
-              id="venue"
-              name="venue"
-              placeholder="e.g., Madison Square Garden"
-            />
+          <div className="grid gap-4 sm:grid-cols-2">
+            <div className="space-y-2">
+              <Label htmlFor="date">Date</Label>
+              <Input id="date" name="date" type="date" />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="venue">Venue</Label>
+              <Input
+                id="venue"
+                name="venue"
+                placeholder="e.g., Madison Square Garden"
+              />
+            </div>
           </div>
 
           <div className="space-y-2">
             <Label>Songs</Label>
-            <div className="border rounded-lg p-4 space-y-4">
-              <div className="space-y-2">
-                {songs.map((song) => (
-                  <div key={song.id} className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      id={`song-${song.id}`}
-                      name="songIds[]"
-                      value={song.id}
-                      className="h-4 w-4 rounded border-gray-300"
-                    />
-                    <label htmlFor={`song-${song.id}`} className="text-sm">
-                      {song.song}
-                    </label>
-                  </div>
-                ))}
-              </div>
-              <p className="text-sm text-muted-foreground">
-                Select songs in the order they were played
-              </p>
-            </div>
+            <SetlistBuilder songs={options} />
           </div>
 
           <div className="flex gap-4">
-            <Button type="submit">Create Setlist</Button>
+            <Button type="submit">Create setlist</Button>
             <Button asChild type="button" variant="outline">
               <Link href="/setlists">Cancel</Link>
             </Button>

--- a/app/(dashboard)/songs/[slug]/page.tsx
+++ b/app/(dashboard)/songs/[slug]/page.tsx
@@ -13,6 +13,9 @@ import { DeleteVideoButton } from "@/components/delete-video-button";
 import { VideoEmbed } from "@/components/video-embed";
 import { Discussion } from "@/components/discussion";
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import Link from "next/link";
 import { createClient } from "@/utils/supabase/server";
 
 export default async function SongPage({
@@ -43,11 +46,34 @@ export default async function SongPage({
   return (
     <div className="container pt-3 pb-7">
       {/* Song header */}
-      <div className="mb-2">
-        <h1 className="text-4xl font-bold">{song.song}</h1>
+      <Button asChild variant="ghost" size="sm" className="mb-2 -ml-2">
+        <Link href="/songs">
+          <ArrowLeft className="mr-1 h-4 w-4" /> Songs
+        </Link>
+      </Button>
+      <div className="mb-4">
+        <h1 className="text-3xl font-bold sm:text-4xl">{song.song}</h1>
         {song.artist && (
           <p className="text-lg text-muted-foreground">By {song.artist}</p>
         )}
+        <div className="mt-2 flex flex-wrap gap-2">
+          {typeof song.times_played === "number" && (
+            <Badge variant="secondary">{song.times_played}× played</Badge>
+          )}
+          {typeof song.gap === "number" && (
+            <Badge variant="secondary">Gap: {song.gap}</Badge>
+          )}
+          {song.last_played && (
+            <Badge variant="secondary">
+              Last: {new Date(song.last_played).toLocaleDateString()}
+            </Badge>
+          )}
+          {song.debut && (
+            <Badge variant="secondary">
+              Debut: {new Date(song.debut).toLocaleDateString()}
+            </Badge>
+          )}
+        </div>
       </div>
 
       <Tabs defaultValue="tabs" className="w-full">

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -10,6 +10,16 @@ const defaultUrl = process.env.VERCEL_URL
   ? `https://${process.env.VERCEL_URL}`
   : "http://localhost:3000";
 
+export const viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover" as const,
+  themeColor: [
+    { media: "(prefers-color-scheme: light)", color: "#ffffff" },
+    { media: "(prefers-color-scheme: dark)", color: "#0a0a0a" },
+  ],
+};
+
 export const metadata = {
   metadataBase: new URL(defaultUrl),
   title: "Phishub - Your Source for Phish Music Resources",

--- a/components/dashboard-home.tsx
+++ b/components/dashboard-home.tsx
@@ -1,14 +1,207 @@
+import Link from "next/link";
+import {
+  Music,
+  Heart,
+  ListMusic,
+  BookOpen,
+  Play,
+  Plus,
+  ArrowRight,
+} from "lucide-react";
 import { DashboardShell } from "@/components/dashboard-shell";
+import { SearchBar } from "@/components/search-bar";
+import { Button } from "@/components/ui/button";
+import {
+  getRecentTabs,
+  getSetlists,
+  getFavoriteTabsForUser,
+} from "@/lib/api";
 
-export default function DashboardHome() {
+const quickLinks = [
+  {
+    href: "/songs",
+    title: "Browse songs",
+    description: "950+ Phish songs",
+    icon: Music,
+    accent: "text-purple-600",
+  },
+  {
+    href: "/tabs",
+    title: "Latest tabs",
+    description: "Newest tabs & chords",
+    icon: BookOpen,
+    accent: "text-orange-500",
+  },
+  {
+    href: "/favorites",
+    title: "Your favorites",
+    description: "Saved tabs & chords",
+    icon: Heart,
+    accent: "text-rose-500",
+  },
+  {
+    href: "/setlists",
+    title: "Setlists",
+    description: "Build & perform sets",
+    icon: ListMusic,
+    accent: "text-emerald-600",
+  },
+];
+
+export default async function DashboardHome() {
+  const [recentTabs, setlists, favorites] = await Promise.all([
+    getRecentTabs(6),
+    getSetlists(4),
+    getFavoriteTabsForUser(),
+  ]);
+
   return (
     <DashboardShell>
-      <div className="p-8">
-        <h1 className="text-3xl font-bold mb-4">Welcome to your Dashboard!</h1>
-        <p className="text-lg text-gray-600">
-          This is your personalized Phishub dashboard. Add your dashboard
-          widgets or content here.
-        </p>
+      <div className="container max-w-5xl space-y-10 py-8">
+        {/* Hero / quick search */}
+        <section className="text-center">
+          <h1 className="text-3xl font-bold tracking-tight sm:text-4xl">
+            Find a tab,{" "}
+            <span className="bg-gradient-to-r from-purple-600 to-orange-500 bg-clip-text text-transparent">
+              start playing
+            </span>
+          </h1>
+          <p className="mt-2 text-muted-foreground">
+            Search a song to jump straight to its tabs, chords, and lyrics.
+          </p>
+          <div className="mt-5">
+            <SearchBar />
+          </div>
+        </section>
+
+        {/* Quick links */}
+        <section className="grid grid-cols-2 gap-3 sm:grid-cols-4">
+          {quickLinks.map((link) => (
+            <Link
+              key={link.href}
+              href={link.href}
+              className="group rounded-xl border bg-card p-4 transition-colors hover:border-primary"
+            >
+              <link.icon className={`h-6 w-6 ${link.accent}`} />
+              <p className="mt-3 font-semibold">{link.title}</p>
+              <p className="text-sm text-muted-foreground">
+                {link.description}
+              </p>
+            </Link>
+          ))}
+        </section>
+
+        {/* Your favorites */}
+        {favorites.length > 0 && (
+          <section>
+            <div className="mb-3 flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Your favorites</h2>
+              <Button asChild variant="ghost" size="sm">
+                <Link href="/favorites">
+                  View all <ArrowRight className="ml-1 h-4 w-4" />
+                </Link>
+              </Button>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {favorites.slice(0, 6).map((tab) => (
+                <Link
+                  key={tab.id}
+                  href={`/songs/${tab.song.slug}`}
+                  className="flex items-center justify-between rounded-lg border bg-card p-3 transition-colors hover:border-primary"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate font-medium">{tab.song.song}</p>
+                    <p className="text-xs capitalize text-muted-foreground">
+                      {tab.type}
+                    </p>
+                  </div>
+                  <Heart className="h-4 w-4 shrink-0 fill-rose-500 text-rose-500" />
+                </Link>
+              ))}
+            </div>
+          </section>
+        )}
+
+        {/* Recent tabs */}
+        <section>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-xl font-semibold">Recently added tabs</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link href="/tabs">
+                View all <ArrowRight className="ml-1 h-4 w-4" />
+              </Link>
+            </Button>
+          </div>
+          {recentTabs.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              No tabs yet. Be the first to add one.
+            </p>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {recentTabs.map((tab) => (
+                <Link
+                  key={tab.id}
+                  href={`/songs/${tab.song.slug}`}
+                  className="rounded-lg border bg-card p-3 transition-colors hover:border-primary"
+                >
+                  <p className="truncate font-medium">{tab.song.song}</p>
+                  <p className="text-xs text-muted-foreground">
+                    <span className="capitalize">{tab.type}</span> · by{" "}
+                    {tab.user?.username ?? "Unknown"}
+                  </p>
+                </Link>
+              ))}
+            </div>
+          )}
+        </section>
+
+        {/* Setlists */}
+        <section>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="text-xl font-semibold">Setlists</h2>
+            <Button asChild variant="ghost" size="sm">
+              <Link href="/setlists/new">
+                <Plus className="mr-1 h-4 w-4" /> New
+              </Link>
+            </Button>
+          </div>
+          {setlists.length === 0 ? (
+            <div className="rounded-xl border border-dashed p-6 text-center">
+              <p className="mb-3 text-sm text-muted-foreground">
+                Create a setlist to use as a hands-free cheat sheet on stage.
+              </p>
+              <Button asChild size="sm">
+                <Link href="/setlists/new">Create your first setlist</Link>
+              </Button>
+            </div>
+          ) : (
+            <div className="grid gap-3 sm:grid-cols-2">
+              {setlists.map((setlist) => (
+                <div
+                  key={setlist.id}
+                  className="flex items-center justify-between gap-2 rounded-lg border bg-card p-4"
+                >
+                  <Link
+                    href={`/setlists/${setlist.id}`}
+                    className="min-w-0 flex-1"
+                  >
+                    <p className="truncate font-medium">{setlist.name}</p>
+                    {setlist.venue && (
+                      <p className="truncate text-sm text-muted-foreground">
+                        {setlist.venue}
+                      </p>
+                    )}
+                  </Link>
+                  <Button asChild size="sm" variant="outline">
+                    <Link href={`/setlists/${setlist.id}/perform`}>
+                      <Play className="mr-1 h-4 w-4" /> Perform
+                    </Link>
+                  </Button>
+                </div>
+              ))}
+            </div>
+          )}
+        </section>
       </div>
     </DashboardShell>
   );

--- a/components/setlist-builder.tsx
+++ b/components/setlist-builder.tsx
@@ -1,0 +1,134 @@
+"use client";
+import * as React from "react";
+import { Plus, X, ChevronUp, ChevronDown, Search, GripVertical } from "lucide-react";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+
+type Option = { id: string; song: string };
+
+export function SetlistBuilder({ songs }: { songs: Option[] }) {
+  const [query, setQuery] = React.useState("");
+  const [selected, setSelected] = React.useState<Option[]>([]);
+
+  const selectedIds = React.useMemo(
+    () => new Set(selected.map((s) => s.id)),
+    [selected]
+  );
+
+  const results = React.useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+    return songs
+      .filter((s) => !selectedIds.has(s.id) && s.song.toLowerCase().includes(q))
+      .slice(0, 25);
+  }, [query, songs, selectedIds]);
+
+  function add(option: Option) {
+    setSelected((prev) => [...prev, option]);
+    setQuery("");
+  }
+  function remove(id: string) {
+    setSelected((prev) => prev.filter((s) => s.id !== id));
+  }
+  function move(index: number, dir: -1 | 1) {
+    setSelected((prev) => {
+      const next = [...prev];
+      const target = index + dir;
+      if (target < 0 || target >= next.length) return prev;
+      [next[index], next[target]] = [next[target], next[index]];
+      return next;
+    });
+  }
+
+  return (
+    <div className="space-y-3">
+      {selected.map((s) => (
+        <input key={s.id} type="hidden" name="songIds[]" value={s.id} />
+      ))}
+
+      <div className="relative">
+        <Search className="pointer-events-none absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search songs to add..."
+          className="pl-9"
+        />
+        {results.length > 0 && (
+          <div className="absolute z-10 mt-1 max-h-64 w-full overflow-auto rounded-md border bg-popover shadow-md">
+            {results.map((s) => (
+              <button
+                key={s.id}
+                type="button"
+                onClick={() => add(s)}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-accent"
+              >
+                <Plus className="h-4 w-4 text-muted-foreground" />
+                {s.song}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {selected.length === 0 ? (
+        <div className="rounded-lg border border-dashed p-6 text-center text-sm text-muted-foreground">
+          No songs added yet. Search above to build your set in order.
+        </div>
+      ) : (
+        <ol className="space-y-2">
+          {selected.map((s, i) => (
+            <li
+              key={s.id}
+              className="flex items-center gap-2 rounded-lg border bg-card p-2 pl-3"
+            >
+              <GripVertical className="h-4 w-4 shrink-0 text-muted-foreground" />
+              <span className="w-6 shrink-0 text-sm tabular-nums text-muted-foreground">
+                {i + 1}.
+              </span>
+              <span className="flex-1 truncate text-sm">{s.song}</span>
+              <div className="flex shrink-0 items-center">
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  aria-label="Move up"
+                  disabled={i === 0}
+                  onClick={() => move(i, -1)}
+                >
+                  <ChevronUp className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7"
+                  aria-label="Move down"
+                  disabled={i === selected.length - 1}
+                  onClick={() => move(i, 1)}
+                >
+                  <ChevronDown className="h-4 w-4" />
+                </Button>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 text-muted-foreground hover:text-destructive"
+                  aria-label="Remove"
+                  onClick={() => remove(s.id)}
+                >
+                  <X className="h-4 w-4" />
+                </Button>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+      <p className="text-xs text-muted-foreground">
+        {selected.length} song{selected.length === 1 ? "" : "s"} · drag-free
+        reordering with the arrows
+      </p>
+    </div>
+  );
+}

--- a/components/setlist-performer.tsx
+++ b/components/setlist-performer.tsx
@@ -1,0 +1,186 @@
+"use client";
+import * as React from "react";
+import Link from "next/link";
+import { ChevronLeft, ChevronRight, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { TabViewer } from "@/components/tab-viewer";
+import { cn } from "@/lib/utils";
+import type { PerformSong } from "@/lib/api";
+
+const LYRICS_KEY = "__lyrics__";
+
+function contentFor(
+  song: PerformSong,
+  key: string
+): { content: string; type: string } | undefined {
+  if (key === LYRICS_KEY) {
+    return song.lyrics
+      ? { content: song.lyrics, type: "lyrics" }
+      : undefined;
+  }
+  const tab = song.tabs.find((t) => t.id === key);
+  return tab ? { content: tab.content, type: tab.type } : undefined;
+}
+
+function defaultKey(song: PerformSong): string | undefined {
+  if (song.tabs.length > 0) return song.tabs[0].id;
+  if (song.lyrics) return LYRICS_KEY;
+  return undefined;
+}
+
+export function SetlistPerformer({
+  name,
+  songs,
+  backHref,
+}: {
+  name: string;
+  songs: PerformSong[];
+  backHref: string;
+}) {
+  const [index, setIndex] = React.useState(0);
+  const [choices, setChoices] = React.useState<Record<string, string>>({});
+  const touchStart = React.useRef<{ x: number; y: number } | null>(null);
+
+  const go = React.useCallback(
+    (next: number) => {
+      setIndex((i) => Math.max(0, Math.min(songs.length - 1, next)));
+    },
+    [songs.length]
+  );
+
+  React.useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement;
+      if (target?.tagName === "INPUT" || target?.tagName === "TEXTAREA") return;
+      if (e.key === "ArrowRight") go(index + 1);
+      if (e.key === "ArrowLeft") go(index - 1);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [index, go]);
+
+  if (songs.length === 0) {
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col items-center justify-center gap-4 bg-background p-6 text-center">
+        <p className="text-muted-foreground">This setlist has no songs yet.</p>
+        <Button asChild>
+          <Link href={backHref}>Back to setlist</Link>
+        </Button>
+      </div>
+    );
+  }
+
+  const song = songs[index];
+  const options = [
+    ...song.tabs.map((t) => ({
+      key: t.id,
+      label: `${t.type} · ${t.username}`,
+    })),
+    ...(song.lyrics ? [{ key: LYRICS_KEY, label: "lyrics" }] : []),
+  ];
+  const activeKey = choices[song.id] ?? defaultKey(song);
+  const active = activeKey ? contentFor(song, activeKey) : undefined;
+
+  function setChoice(key: string) {
+    setChoices((c) => ({ ...c, [song.id]: key }));
+  }
+
+  function onTouchStart(e: React.TouchEvent) {
+    const t = e.touches[0];
+    touchStart.current = { x: t.clientX, y: t.clientY };
+  }
+  function onTouchEnd(e: React.TouchEvent) {
+    const start = touchStart.current;
+    if (!start) return;
+    const t = e.changedTouches[0];
+    const dx = t.clientX - start.x;
+    const dy = t.clientY - start.y;
+    // Horizontal swipe that isn't mostly vertical scrolling.
+    if (Math.abs(dx) > 80 && Math.abs(dx) > Math.abs(dy) * 1.5) {
+      if (dx < 0) go(index + 1);
+      else go(index - 1);
+    }
+    touchStart.current = null;
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex flex-col bg-background"
+      onTouchStart={onTouchStart}
+      onTouchEnd={onTouchEnd}
+    >
+      <header className="flex items-center gap-2 border-b px-3 py-2">
+        <Button asChild variant="ghost" size="icon" className="h-9 w-9 shrink-0">
+          <Link href={backHref} aria-label="Exit performance mode">
+            <X className="h-5 w-5" />
+          </Link>
+        </Button>
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-base font-semibold leading-tight">
+            {song.song}
+          </p>
+          <p className="truncate text-xs text-muted-foreground">
+            {name} · {index + 1} of {songs.length}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-9 w-9"
+            aria-label="Previous song"
+            disabled={index === 0}
+            onClick={() => go(index - 1)}
+          >
+            <ChevronLeft className="h-5 w-5" />
+          </Button>
+          <Button
+            variant="outline"
+            size="icon"
+            className="h-9 w-9"
+            aria-label="Next song"
+            disabled={index === songs.length - 1}
+            onClick={() => go(index + 1)}
+          >
+            <ChevronRight className="h-5 w-5" />
+          </Button>
+        </div>
+      </header>
+
+      {options.length > 1 && (
+        <div className="flex gap-1.5 overflow-x-auto border-b px-3 py-2">
+          {options.map((o) => (
+            <button
+              key={o.key}
+              type="button"
+              onClick={() => setChoice(o.key)}
+              className={cn(
+                "shrink-0 whitespace-nowrap rounded-full border px-3 py-1 text-xs capitalize transition-colors",
+                activeKey === o.key
+                  ? "border-primary bg-primary text-primary-foreground"
+                  : "bg-background text-muted-foreground hover:text-foreground"
+              )}
+            >
+              {o.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="flex-1 overflow-hidden p-3">
+        {active ? (
+          <TabViewer key={`${song.id}:${activeKey}`} tab={active} fill />
+        ) : (
+          <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
+            <p className="text-muted-foreground">
+              No tab, chords, or lyrics available for this song.
+            </p>
+            <Button asChild variant="outline" size="sm">
+              <Link href={`/songs/${song.slug}`}>Open song page</Link>
+            </Button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/components/tab-viewer.tsx
+++ b/components/tab-viewer.tsx
@@ -1,17 +1,305 @@
 "use client";
 import * as React from "react";
+import {
+  ZoomIn,
+  ZoomOut,
+  Maximize2,
+  Minimize2,
+  Play,
+  Pause,
+  Minus,
+  Plus,
+  RotateCcw,
+  Gauge,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { transposeChordSheet, formatSemitones } from "@/lib/chords";
 
-export function TabViewer({
-  tab,
-}: {
+// Approximate width of a monospace character relative to font size. Used to
+// auto-size the font so the widest line fits the available width without
+// wrapping (important for ASCII tabs whose alignment must be preserved).
+const CHAR_WIDTH_RATIO = 0.62;
+const MIN_FONT = 9;
+const MAX_FONT = 34;
+const SCROLL_SPEEDS = [12, 24, 40, 64, 100]; // px per second
+
+export interface TabViewerProps {
   tab?: { content: string; type: string };
-}) {
-  if (!tab)
-    return <div className="text-muted-foreground">No tab selected.</div>;
-  // You can add more logic here for different tab types (e.g., vextab rendering)
+  title?: string;
+  /** Render with its own full-height layout (used inside the setlist performer). */
+  fill?: boolean;
+}
+
+export function TabViewer({ tab, title, fill = false }: TabViewerProps) {
+  const [zoom, setZoom] = React.useState(1);
+  const [semitones, setSemitones] = React.useState(0);
+  const [fullscreen, setFullscreen] = React.useState(false);
+  const [scrolling, setScrolling] = React.useState(false);
+  const [speed, setSpeed] = React.useState(2); // index into SCROLL_SPEEDS
+  const [availWidth, setAvailWidth] = React.useState(0);
+
+  const measureRef = React.useRef<HTMLDivElement>(null);
+  const scrollRef = React.useRef<HTMLDivElement>(null);
+
+  const isChords = tab?.type === "chords";
+
+  const content = React.useMemo(() => {
+    if (!tab) return "";
+    return isChords ? transposeChordSheet(tab.content, semitones) : tab.content;
+  }, [tab, isChords, semitones]);
+
+  const maxLineLength = React.useMemo(() => {
+    let max = 1;
+    for (const line of content.split("\n")) {
+      if (line.length > max) max = line.length;
+    }
+    return max;
+  }, [content]);
+
+  // Measure the available text width and keep it in sync with viewport size
+  // and orientation changes.
+  React.useEffect(() => {
+    const el = measureRef.current;
+    if (!el) return;
+    const update = () => setAvailWidth(el.clientWidth);
+    update();
+    const ro = new ResizeObserver(update);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [fullscreen]);
+
+  const fitFont = React.useMemo(() => {
+    if (!availWidth) return 14;
+    const raw = availWidth / (maxLineLength * CHAR_WIDTH_RATIO);
+    return Math.max(MIN_FONT, Math.min(MAX_FONT, raw));
+  }, [availWidth, maxLineLength]);
+
+  const fontSize = Math.round(fitFont * zoom * 10) / 10;
+  const lineHeight = Math.round(fontSize * 1.45 * 10) / 10;
+
+  // Hands-free auto-scroll for performing.
+  React.useEffect(() => {
+    if (!scrolling) return;
+    const el = scrollRef.current;
+    if (!el) return;
+    let raf = 0;
+    let last = performance.now();
+    const step = (now: number) => {
+      const dt = (now - last) / 1000;
+      last = now;
+      el.scrollTop += SCROLL_SPEEDS[speed] * dt;
+      if (el.scrollTop + el.clientHeight >= el.scrollHeight - 1) {
+        setScrolling(false);
+        return;
+      }
+      raf = requestAnimationFrame(step);
+    };
+    raf = requestAnimationFrame(step);
+    return () => cancelAnimationFrame(raf);
+  }, [scrolling, speed]);
+
+  // Keep the screen awake while in full-screen performance mode.
+  React.useEffect(() => {
+    if (!fullscreen) return;
+    let lock: { release: () => Promise<void> } | null = null;
+    let released = false;
+    const request = async () => {
+      try {
+        lock = (await navigator.wakeLock?.request("screen")) ?? null;
+      } catch {
+        // ignore (unsupported or denied)
+      }
+    };
+    request();
+    const onVisible = () => {
+      if (document.visibilityState === "visible") request();
+    };
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      released = true;
+      document.removeEventListener("visibilitychange", onVisible);
+      lock?.release().catch(() => {});
+      void released;
+    };
+  }, [fullscreen]);
+
+  // Exit fullscreen on Escape.
+  React.useEffect(() => {
+    if (!fullscreen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setFullscreen(false);
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [fullscreen]);
+
+  if (!tab) {
+    return (
+      <div className="text-muted-foreground py-8 text-center">
+        No tab selected.
+      </div>
+    );
+  }
+
+  const controls = (
+    <div className="flex flex-wrap items-center gap-1.5">
+      <div className="flex items-center rounded-md border bg-background">
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          aria-label="Zoom out"
+          onClick={() => setZoom((z) => Math.max(0.4, z - 0.1))}
+        >
+          <ZoomOut className="h-4 w-4" />
+        </Button>
+        <button
+          type="button"
+          onClick={() => setZoom(1)}
+          className="px-1 text-xs tabular-nums text-muted-foreground hover:text-foreground"
+          aria-label="Reset zoom"
+        >
+          {Math.round(zoom * 100)}%
+        </button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-8 w-8"
+          aria-label="Zoom in"
+          onClick={() => setZoom((z) => Math.min(3, z + 0.1))}
+        >
+          <ZoomIn className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {isChords && (
+        <div className="flex items-center rounded-md border bg-background">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label="Transpose down"
+            onClick={() => setSemitones((s) => Math.max(-11, s - 1))}
+          >
+            <Minus className="h-4 w-4" />
+          </Button>
+          <button
+            type="button"
+            onClick={() => setSemitones(0)}
+            className="min-w-[2.75rem] px-1 text-xs tabular-nums text-muted-foreground hover:text-foreground"
+            aria-label="Reset transpose"
+          >
+            {formatSemitones(semitones)} st
+          </button>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8"
+            aria-label="Transpose up"
+            onClick={() => setSemitones((s) => Math.min(11, s + 1))}
+          >
+            <Plus className="h-4 w-4" />
+          </Button>
+        </div>
+      )}
+
+      <Button
+        type="button"
+        variant={scrolling ? "default" : "outline"}
+        size="sm"
+        className="h-8"
+        onClick={() => setScrolling((s) => !s)}
+      >
+        {scrolling ? (
+          <Pause className="h-4 w-4" />
+        ) : (
+          <Play className="h-4 w-4" />
+        )}
+        <span className="ml-1 hidden sm:inline">
+          {scrolling ? "Pause" : "Scroll"}
+        </span>
+      </Button>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8"
+        aria-label="Scroll speed"
+        onClick={() => setSpeed((s) => (s + 1) % SCROLL_SPEEDS.length)}
+      >
+        <Gauge className="h-4 w-4" />
+        <span className="ml-1 tabular-nums">{speed + 1}x</span>
+      </Button>
+
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        className="h-8 w-8"
+        aria-label={fullscreen ? "Exit performance mode" : "Performance mode"}
+        onClick={() => setFullscreen((f) => !f)}
+      >
+        {fullscreen ? (
+          <Minimize2 className="h-4 w-4" />
+        ) : (
+          <Maximize2 className="h-4 w-4" />
+        )}
+      </Button>
+    </div>
+  );
+
+  const pre = (
+    <pre
+      className="whitespace-pre font-mono leading-snug"
+      style={{ fontSize: `${fontSize}px`, lineHeight: `${lineHeight}px` }}
+    >
+      {content}
+    </pre>
+  );
+
+  if (fullscreen) {
+    return (
+      <div className="fixed inset-0 z-50 flex flex-col bg-background">
+        <div className="flex items-center justify-between gap-2 border-b px-3 py-2">
+          <div className="min-w-0">
+            {title && (
+              <p className="truncate text-sm font-semibold">{title}</p>
+            )}
+            <p className="text-xs capitalize text-muted-foreground">
+              {tab.type}
+            </p>
+          </div>
+          {controls}
+        </div>
+        <div ref={scrollRef} className="flex-1 overflow-auto px-3 py-4">
+          <div ref={measureRef} className="w-full">
+            {pre}
+          </div>
+          <div className="h-[40vh]" aria-hidden />
+        </div>
+      </div>
+    );
+  }
+
   return (
-    <div className="border rounded p-4 bg-white">
-      <pre className="whitespace-pre-wrap font-mono text-sm">{tab.content}</pre>
+    <div className={cn("flex flex-col gap-3", fill && "h-full")}>
+      <div className="flex items-center justify-end">{controls}</div>
+      <div
+        ref={scrollRef}
+        className={cn(
+          "overflow-auto rounded-lg border bg-card text-card-foreground px-3 py-3",
+          fill ? "flex-1" : "max-h-[70vh]"
+        )}
+      >
+        <div ref={measureRef} className="w-full">
+          {pre}
+        </div>
+      </div>
     </div>
   );
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -234,6 +234,76 @@ export async function getRecentVideos(limit = 50): Promise<RecentVideo[]> {
   return (data ?? []) as unknown as RecentVideo[];
 }
 
+export type PerformTab = {
+  id: string;
+  type: string;
+  content: string;
+  favorites: number;
+  username: string;
+};
+
+export type PerformSong = {
+  id: string;
+  song: string;
+  slug: string;
+  lyrics: string | null;
+  position: number;
+  tabs: PerformTab[];
+};
+
+export async function getSetlistPerformanceData(id: string): Promise<{
+  setlist: Setlist;
+  songs: PerformSong[];
+}> {
+  const setlist = await getSetlistById(id);
+  const ordered = setlist.setlist_songs.map((e) => ({
+    song: e.songs,
+    position: e.position,
+  }));
+  const songIds = ordered.map((o) => o.song.id);
+
+  const tabsBySong: Record<string, PerformTab[]> = {};
+  if (songIds.length > 0) {
+    const supabase = await createClient();
+    const { data, error } = await supabase
+      .from("tabs")
+      .select(
+        `
+        id,
+        song_id,
+        type,
+        content,
+        user:profiles!author_id (username),
+        favorites:favorites!tab_id (id)
+      `
+      )
+      .in("song_id", songIds);
+    if (error) throw error;
+    for (const t of (data ?? []) as any[]) {
+      (tabsBySong[t.song_id] ??= []).push({
+        id: t.id,
+        type: t.type,
+        content: t.content,
+        favorites: t.favorites ? t.favorites.length : 0,
+        username: t.user?.username ?? "Unknown",
+      });
+    }
+  }
+
+  const songs: PerformSong[] = ordered.map(({ song, position }) => ({
+    id: song.id,
+    song: song.song,
+    slug: song.slug,
+    lyrics: song.lyrics,
+    position,
+    tabs: (tabsBySong[song.id] ?? []).sort((a, b) => b.favorites - a.favorites),
+  }));
+
+  const { setlist_songs, ...meta } = setlist;
+  void setlist_songs;
+  return { setlist: meta as Setlist, songs };
+}
+
 export type FavoriteTab = Tab & { song: { song: string; slug: string } };
 
 export async function getFavoriteTabsForUser(): Promise<FavoriteTab[]> {

--- a/lib/chords.ts
+++ b/lib/chords.ts
@@ -1,0 +1,102 @@
+// Lightweight chord-sheet transposition helpers.
+//
+// These operate on plain-text chord charts (the `chords` tab type): lines that
+// contain only chord tokens are transposed; lyric lines are left untouched so a
+// mixed chords-over-lyrics sheet keeps its words intact.
+
+const SHARP_NOTES = [
+  "C",
+  "C#",
+  "D",
+  "D#",
+  "E",
+  "F",
+  "F#",
+  "G",
+  "G#",
+  "A",
+  "A#",
+  "B",
+];
+const FLAT_NOTES = [
+  "C",
+  "Db",
+  "D",
+  "Eb",
+  "E",
+  "F",
+  "Gb",
+  "G",
+  "Ab",
+  "A",
+  "Bb",
+  "B",
+];
+
+// A single chord token, e.g. "G", "Am7", "F#m7b5", "C/E", "Bsus4".
+const CHORD_RE =
+  /^[A-G](#|b)?(maj|min|m|M|sus|dim|aug|add|ø|°)?\d*(sus\d+)?(add\d+)?(b\d+|#\d+)?(\/[A-G](#|b)?)?$/;
+
+function noteIndex(note: string): number | null {
+  const sharp = SHARP_NOTES.indexOf(note);
+  if (sharp !== -1) return sharp;
+  const flat = FLAT_NOTES.indexOf(note);
+  if (flat !== -1) return flat;
+  return null;
+}
+
+function shiftNote(note: string, semitones: number, preferFlats: boolean) {
+  const idx = noteIndex(note);
+  if (idx === null) return note;
+  const next = (((idx + semitones) % 12) + 12) % 12;
+  return (preferFlats ? FLAT_NOTES : SHARP_NOTES)[next];
+}
+
+function transposeChord(
+  chord: string,
+  semitones: number,
+  preferFlats: boolean
+): string {
+  const [main, bass] = chord.split("/");
+  const m = main.match(/^([A-G](?:#|b)?)(.*)$/);
+  if (!m) return chord;
+
+  let out = shiftNote(m[1], semitones, preferFlats) + m[2];
+  if (bass !== undefined) {
+    const bm = bass.match(/^([A-G](?:#|b)?)(.*)$/);
+    out +=
+      "/" + (bm ? shiftNote(bm[1], semitones, preferFlats) + bm[2] : bass);
+  }
+  return out;
+}
+
+function isChordLine(line: string): boolean {
+  const tokens = line.trim().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return false;
+  return tokens.every((t) => CHORD_RE.test(t));
+}
+
+/**
+ * Transpose a chord chart by a number of semitones. Positive transposes up,
+ * negative down. Lyric lines (anything that isn't all chord tokens) are
+ * returned unchanged.
+ */
+export function transposeChordSheet(content: string, semitones: number): string {
+  if (!semitones) return content;
+  const preferFlats = semitones < 0;
+  return content
+    .split("\n")
+    .map((line) =>
+      isChordLine(line)
+        ? line.replace(/\S+/g, (tok) =>
+            transposeChord(tok, semitones, preferFlats)
+          )
+        : line
+    )
+    .join("\n");
+}
+
+export function formatSemitones(semitones: number): string {
+  if (semitones === 0) return "0";
+  return semitones > 0 ? `+${semitones}` : `${semitones}`;
+}


### PR DESCRIPTION
Redesign the core experience around fast access to a song's tab/chords
and using setlists as hands-free cheat sheets during a performance.

- Tab viewer: rewrite into a mobile-optimized performance viewer that
  auto-fits font size to screen width/orientation (ResizeObserver),
  with zoom, chord transpose, hands-free auto-scroll, a full-screen
  Performance Mode, screen wake-lock, and dark-mode awareness.
- Setlist Performance Mode (/setlists/[id]/perform): a swipeable,
  full-screen cheat sheet that chains a setlist's songs and switches
  between each song's tab/chords/lyrics.
- Searchable setlist builder replacing the 950-checkbox form, with
  ordered add/remove/reorder.
- Modern dashboard home: quick search, quick links, favorites, recent
  tabs, and setlists with one-tap Perform.
- Song page: key stats surfaced as badges + back nav.
- Mobile viewport meta (viewport-fit, theme-color).

https://claude.ai/code/session_01R3zwKVP45RaBszLCMA67Pe