### PR TITLE
Tighten mobile layout, fix nested scroll, refresh nav and song cards

### DIFF
--- a/app/(dashboard)/profile/page.tsx
+++ b/app/(dashboard)/profile/page.tsx
@@ -1,0 +1,52 @@
+import { createClient } from "@/utils/supabase/server";
+import { redirect } from "next/navigation";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { MapPin, Mail } from "lucide-react";
+
+export default async function ProfilePage() {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect("/sign-in");
+
+  const { data: profile } = await supabase
+    .from("profiles")
+    .select("username, avatar_url, country, state, city")
+    .eq("user_id", user.id)
+    .single();
+
+  const location = [profile?.city, profile?.state, profile?.country]
+    .filter(Boolean)
+    .join(", ");
+  const initials = (profile?.username ?? user.email ?? "?")
+    .slice(0, 2)
+    .toUpperCase();
+
+  return (
+    <div className="container max-w-2xl py-6">
+      <h1 className="mb-6 text-2xl font-bold sm:text-3xl">Profile</h1>
+      <div className="flex items-center gap-4 rounded-lg border p-4 sm:p-6">
+        <Avatar className="h-16 w-16 sm:h-20 sm:w-20">
+          {profile?.avatar_url && (
+            <AvatarImage src={profile.avatar_url} alt={profile.username} />
+          )}
+          <AvatarFallback className="text-lg">{initials}</AvatarFallback>
+        </Avatar>
+        <div className="min-w-0 space-y-1">
+          <p className="truncate text-xl font-semibold">
+            {profile?.username ?? "Phishub user"}
+          </p>
+          <p className="flex items-center gap-1.5 truncate text-sm text-muted-foreground">
+            <Mail className="h-4 w-4 shrink-0" /> {user.email}
+          </p>
+          {location && (
+            <p className="flex items-center gap-1.5 truncate text-sm text-muted-foreground">
+              <MapPin className="h-4 w-4 shrink-0" /> {location}
+            </p>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/(dashboard)/songs/[slug]/page.tsx
+++ b/app/(dashboard)/songs/[slug]/page.tsx
@@ -56,24 +56,6 @@ export default async function SongPage({
         {song.artist && (
           <p className="text-lg text-muted-foreground">By {song.artist}</p>
         )}
-        <div className="mt-2 flex flex-wrap gap-2">
-          {typeof song.times_played === "number" && (
-            <Badge variant="secondary">{song.times_played}× played</Badge>
-          )}
-          {typeof song.gap === "number" && (
-            <Badge variant="secondary">Gap: {song.gap}</Badge>
-          )}
-          {song.last_played && (
-            <Badge variant="secondary">
-              Last: {new Date(song.last_played).toLocaleDateString()}
-            </Badge>
-          )}
-          {song.debut && (
-            <Badge variant="secondary">
-              Debut: {new Date(song.debut).toLocaleDateString()}
-            </Badge>
-          )}
-        </div>
       </div>
 
       <Tabs defaultValue="tabs" className="w-full">

--- a/app/(dashboard)/songs/page.tsx
+++ b/app/(dashboard)/songs/page.tsx
@@ -17,10 +17,10 @@ export default async function SongsPage({
   const page = Math.max(1, Number(pageParam) || 1);
 
   return (
-    <div className="container py-10">
-      <h1 className="text-3xl font-bold mb-6">Songs</h1>
+    <div className="container py-6">
+      <h1 className="text-2xl font-bold mb-4 sm:text-3xl">Songs</h1>
 
-      <form action="/songs" className="flex gap-2 mb-8 max-w-md">
+      <form action="/songs" className="flex gap-2 mb-6 max-w-md">
         <Input
           type="search"
           name="q"

--- a/components/dashboard-header.tsx
+++ b/components/dashboard-header.tsx
@@ -1,0 +1,37 @@
+"use client";
+import { useEffect, useState } from "react";
+import { SidebarTrigger } from "@/components/ui/sidebar";
+import { UserMenu } from "@/components/user-menu";
+import { cn } from "@/lib/utils";
+
+// Sticky top bar that hides when scrolling down and reappears instantly on
+// scroll up, so the sidebar trigger and user menu stay reachable without
+// permanently eating vertical space (important on mobile).
+export function DashboardHeader({ hideWaitlist }: { hideWaitlist: boolean }) {
+  const [hidden, setHidden] = useState(false);
+
+  useEffect(() => {
+    let last = window.scrollY;
+    const onScroll = () => {
+      const y = window.scrollY;
+      // Ignore tiny jitters and rubber-band scrolling near the top.
+      if (Math.abs(y - last) < 6) return;
+      setHidden(y > last && y > 56);
+      last = y;
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
+  return (
+    <header
+      className={cn(
+        "sticky top-0 z-30 flex items-center justify-between gap-2 border-b bg-background/80 px-2 py-2 backdrop-blur transition-transform duration-200 sm:px-3",
+        hidden && "-translate-y-full"
+      )}
+    >
+      <SidebarTrigger />
+      <UserMenu hideWaitlist={hideWaitlist} />
+    </header>
+  );
+}

--- a/components/dashboard-shell.tsx
+++ b/components/dashboard-shell.tsx
@@ -21,12 +21,11 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarTrigger,
   SidebarInset,
 } from "@/components/ui/sidebar";
 import Link from "next/link";
 import { SearchBar } from "@/components/search-bar";
-import { UserMenu } from "@/components/user-menu";
+import { DashboardHeader } from "@/components/dashboard-header";
 import { waitlistDisabled } from "@/flags";
 
 const items = [
@@ -70,13 +69,8 @@ export async function DashboardShell({ children }: { children: ReactNode }) {
         </SidebarContent>
       </Sidebar>
       <SidebarInset>
-        <main>
-          <div className="w-full flex items-center justify-between pl-4 pt-2 pb-2 pr-4">
-            <SidebarTrigger />
-            <UserMenu hideWaitlist={waitlist} />
-          </div>
-          {children}
-        </main>
+        <DashboardHeader hideWaitlist={waitlist} />
+        {children}
       </SidebarInset>
     </SidebarProvider>
   );

--- a/components/song-list.tsx
+++ b/components/song-list.tsx
@@ -1,28 +1,39 @@
 import Link from "next/link";
-import { Song } from "@/types";
+import { BookOpen, Video, FileText } from "lucide-react";
+import { SongCard } from "@/lib/api";
 
-export function SongList({ songs }: { songs: Song[] }) {
+export function SongList({ songs }: { songs: SongCard[] }) {
   return (
-    <div className="grid gap-4">
+    <div className="divide-y overflow-hidden rounded-lg border">
       {songs.map((song) => (
         <Link
           key={song.id}
           href={`/songs/${song.slug}`}
-          className="p-4 rounded-lg border hover:border-primary transition-colors"
+          className="flex items-center justify-between gap-3 px-3 py-2.5 transition-colors hover:bg-accent"
         >
-          <div className="flex items-center justify-between">
-            <div>
-              <h3 className="text-lg font-semibold">{song.song}</h3>
-              {song.artist && (
-                <p className="text-sm text-muted-foreground">
-                  By {song.artist}
-                </p>
-              )}
-            </div>
-            {song.debut && (
-              <div className="text-sm text-muted-foreground">
-                Debuted: {new Date(song.debut).toLocaleDateString()}
-              </div>
+          <div className="min-w-0">
+            <h3 className="truncate font-medium leading-tight">{song.song}</h3>
+            {song.artist && (
+              <p className="truncate text-xs text-muted-foreground">
+                {song.artist}
+              </p>
+            )}
+          </div>
+          <div className="flex shrink-0 items-center gap-2.5 text-muted-foreground">
+            {song.hasTabs && (
+              <BookOpen
+                className="h-4 w-4 text-purple-600"
+                aria-label="Has tabs"
+              />
+            )}
+            {song.hasVideos && (
+              <Video
+                className="h-4 w-4 text-orange-500"
+                aria-label="Has videos"
+              />
+            )}
+            {song.hasLyrics && (
+              <FileText className="h-4 w-4" aria-label="Has lyrics" />
             )}
           </div>
         </Link>

--- a/components/tab-viewer.tsx
+++ b/components/tab-viewer.tsx
@@ -78,18 +78,26 @@ export function TabViewer({ tab, title, fill = false }: TabViewerProps) {
   const fontSize = Math.round(fitFont * zoom * 10) / 10;
   const lineHeight = Math.round(fontSize * 1.45 * 10) / 10;
 
-  // Hands-free auto-scroll for performing.
+  // Hands-free auto-scroll for performing. When the viewer has its own scroll
+  // container (fullscreen / setlist fill mode) we scroll that; otherwise we
+  // drive the page itself so the inline view never becomes a nested scroller.
   React.useEffect(() => {
     if (!scrolling) return;
     const el = scrollRef.current;
-    if (!el) return;
+    const useEl = !!el && el.scrollHeight > el.clientHeight + 1;
+    const pageEl = (document.scrollingElement ||
+      document.documentElement) as HTMLElement;
+    // Accumulate fractionally so slow speeds aren't lost to integer rounding.
+    let pos = useEl ? el!.scrollTop : pageEl.scrollTop;
     let raf = 0;
     let last = performance.now();
     const step = (now: number) => {
       const dt = (now - last) / 1000;
       last = now;
-      el.scrollTop += SCROLL_SPEEDS[speed] * dt;
-      if (el.scrollTop + el.clientHeight >= el.scrollHeight - 1) {
+      pos += SCROLL_SPEEDS[speed] * dt;
+      const target = useEl ? el! : pageEl;
+      target.scrollTop = pos;
+      if (pos + target.clientHeight >= target.scrollHeight - 1) {
         setScrolling(false);
         return;
       }
@@ -292,8 +300,11 @@ export function TabViewer({ tab, title, fill = false }: TabViewerProps) {
       <div
         ref={scrollRef}
         className={cn(
-          "overflow-auto rounded-lg border bg-card text-card-foreground px-3 py-3",
-          fill ? "flex-1" : "max-h-[70vh]"
+          "rounded-lg border bg-card text-card-foreground px-3 py-3",
+          // Fill mode (setlist performer) keeps its own scroll area; the inline
+          // song-page view flows with the page and only scrolls horizontally
+          // as a last resort for ultra-wide tabs.
+          fill ? "flex-1 overflow-auto" : "overflow-x-auto"
         )}
       >
         <div ref={measureRef} className="w-full">

--- a/components/user-menu.tsx
+++ b/components/user-menu.tsx
@@ -1,31 +1,25 @@
 "use client";
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 import { Button } from "@/components/ui/button";
 import { CurrentUserAvatar } from "@/components/current-user-avatar";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
 import { LogOut, User } from "lucide-react";
 import { useEffect, useState } from "react";
 import { createClient } from "@/utils/supabase/client";
 
 export function UserMenu({ hideWaitlist }: { hideWaitlist: boolean }) {
   const [user, setUser] = useState<any>(null);
-  const [profile, setProfile] = useState<any>(null);
-  const router = useRouter();
   const supabase = createClient();
 
   useEffect(() => {
     supabase.auth.getUser().then(({ data }: any) => {
       setUser(data?.user);
-      if (data?.user) {
-        supabase
-          .from("profiles")
-          .select("avatar_url")
-          .eq("user_id", data.user.id)
-          .single()
-          .then(({ data: profileData }) => {
-            setProfile(profileData);
-          });
-      }
     });
   }, [supabase]);
 
@@ -51,11 +45,27 @@ export function UserMenu({ hideWaitlist }: { hideWaitlist: boolean }) {
   }
 
   return (
-    <div className="flex items-center gap-3">
-      <CurrentUserAvatar />
-      <Button variant="ghost" size="sm" onClick={handleSignOut}>
-        <LogOut className="h-4 w-4 mr-1" /> Sign Out
-      </Button>
-    </div>
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <button
+          type="button"
+          className="rounded-full outline-none ring-offset-background transition-shadow focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+          aria-label="Open user menu"
+        >
+          <CurrentUserAvatar />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-44">
+        <DropdownMenuItem asChild>
+          <Link href="/profile">
+            <User className="mr-2 h-4 w-4" /> Profile
+          </Link>
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onClick={handleSignOut}>
+          <LogOut className="mr-2 h-4 w-4" /> Sign Out
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -11,6 +11,32 @@ export async function getSongs() {
   return songs as Song[];
 }
 
+export type SongCard = Song & {
+  hasTabs: boolean;
+  hasVideos: boolean;
+  hasLyrics: boolean;
+};
+
+// Annotate a list of songs with flags for whether each has tabs, videos, and
+// lyrics — used to show at-a-glance indicators on the songs index.
+async function attachContentIndicators(songs: Song[]): Promise<SongCard[]> {
+  if (songs.length === 0) return [];
+  const supabase = await createClient();
+  const ids = songs.map((s) => s.id);
+  const [{ data: tabRows }, { data: videoRows }] = await Promise.all([
+    supabase.from("tabs").select("song_id").in("song_id", ids),
+    supabase.from("videos").select("song_id").in("song_id", ids),
+  ]);
+  const tabSet = new Set((tabRows ?? []).map((r) => r.song_id as string));
+  const videoSet = new Set((videoRows ?? []).map((r) => r.song_id as string));
+  return songs.map((song) => ({
+    ...song,
+    hasTabs: tabSet.has(song.id),
+    hasVideos: videoSet.has(song.id),
+    hasLyrics: !!song.lyrics && song.lyrics.trim().length > 0,
+  }));
+}
+
 export async function getSongsPage(page = 1, pageSize = 50) {
   const supabase = await createClient();
   const from = (page - 1) * pageSize;
@@ -25,7 +51,8 @@ export async function getSongsPage(page = 1, pageSize = 50) {
     .order("song", { ascending: true })
     .range(from, to);
   if (error) throw error;
-  return { songs: (songs ?? []) as Song[], total: count ?? 0 };
+  const cards = await attachContentIndicators((songs ?? []) as Song[]);
+  return { songs: cards, total: count ?? 0 };
 }
 
 export async function getSongBySlug(slug: string) {
@@ -87,7 +114,7 @@ export async function searchSongs(query: string) {
     .or(`song.ilike.%${query}%, lyrics.ilike.%${query}%`)
     .order("times_played", { ascending: false });
   if (error) throw error;
-  return songs as Song[];
+  return attachContentIndicators((songs ?? []) as Song[]);
 }
 
 export async function getComments(type: "song" | "tab", id: string) {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -12,7 +12,11 @@ const config = {
   theme: {
   	container: {
   		center: true,
-  		padding: '2rem',
+  		padding: {
+  			DEFAULT: '0.75rem',
+  			sm: '1.5rem',
+  			lg: '2rem'
+  		},
   		screens: {
   			'2xl': '1400px'
   		}


### PR DESCRIPTION
- Reduce container horizontal padding (0.75rem mobile → 2rem desktop) to
  maximize viewport on small screens
- Add a sticky dashboard header that hides on scroll-down and reappears on
  scroll-up so the sidebar trigger and user menu stay reachable
- Stop the inline tab viewer from being a nested scroller: it now flows with
  the page (only horizontal overflow as a last resort) and auto-scroll drives
  the window; fullscreen/setlist fill mode keep their own scroll area
- Remove the times-played / gap / last-played / debut pills from the song page
- Compact the songs index into a dense list with tab/video/lyrics indicator
  icons; drop the debut date
- Replace the avatar + "Sign Out" button with an avatar dropdown menu
  (Profile link + Sign Out) and add a minimal profile page