### PR TITLE
Add tab editor with live preview, author edit flow, and contributor terms

### DIFF
--- a/app/(dashboard)/songs/[slug]/page.tsx
+++ b/app/(dashboard)/songs/[slug]/page.tsx
@@ -75,6 +75,7 @@ export default async function SongPage({
             tabs={tabs}
             userFavoriteTabIds={userFavoriteTabIds}
             canFavorite={isAuthed}
+            currentUserId={user?.id}
             revalidate={revalidatePath}
           />
         </TabsContent>

--- a/app/actions.ts
+++ b/app/actions.ts
@@ -168,6 +168,12 @@ export async function createTab(formData: FormData) {
   } = await supabase.auth.getUser();
   if (!user) throw new Error("Not authenticated");
 
+  // Contributor license acknowledgement (see /content-policy). Enforced here as
+  // well as in the UI so the grant can't be bypassed by a crafted request.
+  if (formData.get("agree") !== "yes") {
+    throw new Error("You must accept the content policy to submit a tab");
+  }
+
   const songId = formData.get("songId") as string;
   const slug = formData.get("slug") as string;
   const content = formData.get("content") as string;
@@ -183,6 +189,39 @@ export async function createTab(formData: FormData) {
   if (error) throw error;
 
   if (slug) revalidatePath(`/songs/${slug}`);
+  revalidatePath("/tabs");
+}
+
+export async function updateTab(formData: FormData) {
+  const supabase = await createClient();
+
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) throw new Error("Not authenticated");
+
+  if (formData.get("agree") !== "yes") {
+    throw new Error("You must accept the content policy to save a tab");
+  }
+
+  const tabId = formData.get("tabId") as string;
+  const content = formData.get("content") as string;
+  const type = formData.get("type") as string;
+  const revalidate = formData.get("revalidate") as string;
+
+  if (!tabId) throw new Error("Missing tab id");
+
+  // The author_id filter mirrors the RLS update policy — only the author can
+  // edit their own tab.
+  const { error } = await supabase
+    .from("tabs")
+    .update({ content, type })
+    .eq("id", tabId)
+    .eq("author_id", user.id);
+
+  if (error) throw error;
+
+  if (revalidate) revalidatePath(revalidate);
   revalidatePath("/tabs");
 }
 

--- a/app/content-policy/page.tsx
+++ b/app/content-policy/page.tsx
@@ -1,0 +1,113 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+
+// Designated contact for contributor-license questions and copyright/DMCA
+// takedown notices. Update this to the real monitored address before launch.
+const COPYRIGHT_CONTACT = "copyright@phishub.com";
+
+export const metadata = {
+  title: "Content & Copyright Policy - Phishub",
+  description:
+    "How user-contributed tabs are licensed on Phishub, and how to submit a copyright takedown notice.",
+};
+
+export default function ContentPolicyPage() {
+  return (
+    <div className="container max-w-3xl py-10">
+      <Button asChild variant="ghost" size="sm" className="mb-4 -ml-2">
+        <Link href="/">
+          <ArrowLeft className="mr-1 h-4 w-4" /> Home
+        </Link>
+      </Button>
+
+      <h1 className="text-3xl font-bold sm:text-4xl">
+        Content &amp; Copyright Policy
+      </h1>
+      <p className="mt-2 text-muted-foreground">
+        How community-contributed tabs work on Phishub.
+      </p>
+
+      <div className="prose mt-8 max-w-none space-y-8 text-sm leading-relaxed">
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">Community contributions</h2>
+          <p>
+            Tabs, chords, and transcriptions on Phishub are created and uploaded
+            by the community. Phishub is a hosting platform for those
+            contributions — it does not sell or distribute official sheet music.
+            Official transcriptions can be purchased from the band&apos;s own
+            stores.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            Your responsibilities as a contributor
+          </h2>
+          <p>When you submit a tab, you confirm that:</p>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>
+              It is <strong>your own original transcription</strong> — your
+              interpretation of how to play the song — and not a copy of someone
+              else&apos;s published tablature or copyrighted sheet music.
+            </li>
+            <li>
+              You are not uploading scanned, photographed, or copied official
+              sheet music or publisher-owned arrangements.
+            </li>
+            <li>
+              You grant Phishub a non-exclusive, royalty-free license to host,
+              display, and distribute your contribution on the platform, with
+              attribution to your account.
+            </li>
+          </ul>
+          <p>
+            You retain ownership of your transcription and may request its
+            removal at any time.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">Underlying compositions</h2>
+          <p>
+            Tabs are transcriptions of musical works whose compositions and
+            lyrics remain the property of their respective copyright holders.
+            Contributions are shared for educational and personal use. If you
+            are a rights holder and believe content here exceeds that scope, use
+            the takedown process below.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            Copyright takedown (DMCA) requests
+          </h2>
+          <p>
+            If you are a copyright owner (or authorized agent) and believe
+            material on Phishub infringes your rights, email our designated
+            contact with:
+          </p>
+          <ul className="list-disc space-y-1 pl-6">
+            <li>Identification of the work and the specific URL(s) at issue.</li>
+            <li>Your contact information.</li>
+            <li>
+              A statement that you have a good-faith belief the use is not
+              authorized, and that the information in your notice is accurate.
+            </li>
+          </ul>
+          <p>
+            Send notices to{" "}
+            <a
+              href={`mailto:${COPYRIGHT_CONTACT}`}
+              className="font-medium underline hover:text-foreground"
+            >
+              {COPYRIGHT_CONTACT}
+            </a>
+            . We remove material that is the subject of a valid notice and may
+            disable repeat infringers&apos; accounts.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/add-tab-dialog.tsx
+++ b/components/add-tab-dialog.tsx
@@ -28,7 +28,7 @@ export function AddTabDialog({
           <Plus className="h-4 w-4 mr-1" /> Add tab
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Add a tab</DialogTitle>
         </DialogHeader>

--- a/components/edit-tab-dialog.tsx
+++ b/components/edit-tab-dialog.tsx
@@ -1,6 +1,6 @@
 "use client";
 import * as React from "react";
-import { createTab } from "@/app/actions";
+import { updateTab } from "@/app/actions";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -10,32 +10,39 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { TabEditor } from "@/components/tab-editor";
-import { Plus } from "lucide-react";
+import { Pencil } from "lucide-react";
 
-export function AddTabDialog({
-  songId,
-  slug,
+export function EditTabDialog({
+  tab,
+  revalidate,
 }: {
-  songId: string;
-  slug: string;
+  tab: { id: string; type: string; content: string };
+  revalidate?: string;
 }) {
   const [open, setOpen] = React.useState(false);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button size="sm">
-          <Plus className="h-4 w-4 mr-1" /> Add tab
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-8 w-8"
+          aria-label="Edit tab"
+        >
+          <Pencil className="h-4 w-4" />
         </Button>
       </DialogTrigger>
       <DialogContent className="sm:max-w-2xl">
         <DialogHeader>
-          <DialogTitle>Add a tab</DialogTitle>
+          <DialogTitle>Edit tab</DialogTitle>
         </DialogHeader>
         <TabEditor
-          action={createTab}
-          hiddenFields={{ songId, slug }}
-          submitLabel="Save tab"
+          action={updateTab}
+          hiddenFields={{ tabId: tab.id, revalidate: revalidate ?? "" }}
+          defaultType={tab.type}
+          defaultContent={tab.content}
+          submitLabel="Save changes"
           onDone={() => setOpen(false)}
         />
       </DialogContent>

--- a/components/edit-tab-dialog.tsx
+++ b/components/edit-tab-dialog.tsx
@@ -33,7 +33,7 @@ export function EditTabDialog({
           <Pencil className="h-4 w-4" />
         </Button>
       </DialogTrigger>
-      <DialogContent className="sm:max-w-2xl">
+      <DialogContent className="max-h-[90vh] overflow-y-auto sm:max-w-2xl">
         <DialogHeader>
           <DialogTitle>Edit tab</DialogTitle>
         </DialogHeader>

--- a/components/tab-editor.tsx
+++ b/components/tab-editor.tsx
@@ -106,7 +106,7 @@ export function TabEditor({
           <>
             {/* Keep the content in the form while previewing. */}
             <input type="hidden" name="content" value={content} />
-            <div className="min-h-[16rem] overflow-x-auto rounded-md border bg-card px-3 py-3 text-card-foreground">
+            <div className="max-h-[45vh] min-h-[12rem] overflow-auto rounded-md border bg-card px-3 py-3 text-card-foreground">
               {content.trim() ? (
                 <pre className="whitespace-pre font-mono text-sm leading-snug">
                   {content}

--- a/components/tab-editor.tsx
+++ b/components/tab-editor.tsx
@@ -1,0 +1,155 @@
+"use client";
+import * as React from "react";
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+// Shared editor body for adding and editing tabs. Renders the whole <form> so
+// it can wrap a server action; callers supply the action plus any hidden
+// fields (songId/slug for create, tabId/revalidate for edit). A monospace,
+// no-wrap textarea preserves ASCII-tab alignment, and a Write/Preview toggle
+// shows readers' exact rendering before saving. Submission is gated on the
+// contributor-license checkbox (also enforced server-side via the `agree`
+// field).
+export function TabEditor({
+  action,
+  hiddenFields = {},
+  defaultType = "tab",
+  defaultContent = "",
+  submitLabel = "Save tab",
+  onDone,
+}: {
+  action: (formData: FormData) => Promise<void> | void;
+  hiddenFields?: Record<string, string>;
+  defaultType?: string;
+  defaultContent?: string;
+  submitLabel?: string;
+  onDone?: () => void;
+}) {
+  const [content, setContent] = React.useState(defaultContent);
+  const [agree, setAgree] = React.useState(false);
+  const [mode, setMode] = React.useState<"write" | "preview">("write");
+  const [pending, setPending] = React.useState(false);
+
+  async function handle(formData: FormData) {
+    setPending(true);
+    try {
+      await action(formData);
+      onDone?.();
+    } finally {
+      setPending(false);
+    }
+  }
+
+  const canSave = agree && content.trim().length > 0;
+
+  return (
+    <form action={handle} className="space-y-4">
+      {Object.entries(hiddenFields).map(([name, value]) => (
+        <input key={name} type="hidden" name={name} value={value} />
+      ))}
+      <input type="hidden" name="agree" value={agree ? "yes" : ""} />
+
+      <div className="space-y-2">
+        <Label htmlFor="type">Type</Label>
+        <select
+          id="type"
+          name="type"
+          defaultValue={defaultType}
+          className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm"
+        >
+          <option value="tab">Tab</option>
+          <option value="chords">Chords</option>
+          <option value="vextab">VexTab</option>
+        </select>
+      </div>
+
+      <div className="space-y-2">
+        <div className="flex items-center justify-between">
+          <Label htmlFor="content">Content</Label>
+          <div className="inline-flex rounded-md border p-0.5 text-xs">
+            {(["write", "preview"] as const).map((m) => (
+              <button
+                key={m}
+                type="button"
+                onClick={() => setMode(m)}
+                className={cn(
+                  "rounded px-2 py-1 capitalize transition-colors",
+                  mode === m
+                    ? "bg-primary text-primary-foreground"
+                    : "text-muted-foreground hover:text-foreground"
+                )}
+              >
+                {m}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {mode === "write" ? (
+          <Textarea
+            id="content"
+            name="content"
+            required
+            rows={14}
+            wrap="off"
+            spellCheck={false}
+            className="overflow-x-auto font-mono text-sm"
+            value={content}
+            onChange={(e) => setContent(e.target.value)}
+            placeholder="Paste or type the tab here..."
+          />
+        ) : (
+          <>
+            {/* Keep the content in the form while previewing. */}
+            <input type="hidden" name="content" value={content} />
+            <div className="min-h-[16rem] overflow-x-auto rounded-md border bg-card px-3 py-3 text-card-foreground">
+              {content.trim() ? (
+                <pre className="whitespace-pre font-mono text-sm leading-snug">
+                  {content}
+                </pre>
+              ) : (
+                <p className="text-sm text-muted-foreground">
+                  Nothing to preview yet.
+                </p>
+              )}
+            </div>
+          </>
+        )}
+        <p className="text-xs text-muted-foreground">
+          Alignment is preserved exactly. Use spaces (not tab characters) so the
+          tab renders the same for everyone.
+        </p>
+      </div>
+
+      <label className="flex items-start gap-2 text-sm">
+        <Checkbox
+          checked={agree}
+          onCheckedChange={(v) => setAgree(v === true)}
+          className="mt-0.5"
+        />
+        <span className="text-muted-foreground">
+          This is my own original transcription, and I grant Phishub a
+          non-exclusive license to display it. See our{" "}
+          <Link
+            href="/content-policy"
+            target="_blank"
+            className="underline hover:text-foreground"
+          >
+            content &amp; copyright policy
+          </Link>
+          .
+        </span>
+      </label>
+
+      <div className="flex justify-end">
+        <Button type="submit" disabled={!canSave || pending}>
+          {pending ? "Saving…" : submitLabel}
+        </Button>
+      </div>
+    </form>
+  );
+}

--- a/components/tab-section.tsx
+++ b/components/tab-section.tsx
@@ -3,22 +3,26 @@ import * as React from "react";
 import { TabSelector } from "@/components/tab-selector";
 import { TabViewer } from "@/components/tab-viewer";
 import { FavoriteButton } from "@/components/favorite-button";
+import { EditTabDialog } from "@/components/edit-tab-dialog";
 
 export function TabSection({
   tabs,
   userFavoriteTabIds = [],
   canFavorite = false,
+  currentUserId,
   revalidate,
 }: {
   tabs: Array<{
     id: string;
     type: string;
     favorites: number;
+    author_id: string;
     user: { username: string; avatar_url?: string };
     content: string;
   }>;
   userFavoriteTabIds?: string[];
   canFavorite?: boolean;
+  currentUserId?: string;
   revalidate?: string;
 }) {
   const [selectedTabId, setSelectedTabId] = React.useState<string | undefined>(
@@ -56,6 +60,9 @@ export function TabSection({
             initialCount={selectedTab.favorites}
             revalidate={revalidate}
           />
+        )}
+        {selectedTab && currentUserId === selectedTab.author_id && (
+          <EditTabDialog tab={selectedTab} revalidate={revalidate} />
         )}
       </div>
       <TabViewer tab={selectedTab} />


### PR DESCRIPTION
Build out community tab contribution as a first-party feature:

- New TabEditor component: monospace no-wrap textarea that preserves ASCII
  alignment, plus a Write/Preview toggle that renders readers' exact output.
- Author edit flow: EditTabDialog + updateTab server action, surfaced only to
  the tab's author (mirrors the RLS update policy).
- Contributor license: required acknowledgement checkbox on add/edit, enforced
  server-side via the agree field, linking to a new /content-policy page
  covering the contributor license and a DMCA/copyright takedown contact.

Refactors AddTabDialog onto the shared editor.