### PR TITLE
Add sidebar icon colors and larger nav, infinite scroll for songs/videos

### DIFF
--- a/app/(dashboard)/songs/actions.ts
+++ b/app/(dashboard)/songs/actions.ts
@@ -1,0 +1,9 @@
+"use server";
+
+import { getSongsPage } from "@/lib/api";
+
+// Read action used by the songs infinite-scroll list to fetch the next page
+// from a Client Component.
+export async function fetchSongsPage(page: number, pageSize: number) {
+  return getSongsPage(page, pageSize);
+}

--- a/app/(dashboard)/songs/page.tsx
+++ b/app/(dashboard)/songs/page.tsx
@@ -1,5 +1,6 @@
 import { getSongsPage, searchSongs } from "@/lib/api";
 import { SongList } from "@/components/song-list";
+import { SongsInfinite } from "@/components/songs-infinite";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Search } from "lucide-react";
@@ -10,11 +11,10 @@ const PAGE_SIZE = 50;
 export default async function SongsPage({
   searchParams,
 }: {
-  searchParams: Promise<{ q?: string; page?: string }>;
+  searchParams: Promise<{ q?: string }>;
 }) {
-  const { q, page: pageParam } = await searchParams;
+  const { q } = await searchParams;
   const query = q?.trim() ?? "";
-  const page = Math.max(1, Number(pageParam) || 1);
 
   return (
     <div className="container py-6">
@@ -32,11 +32,7 @@ export default async function SongsPage({
         </Button>
       </form>
 
-      {query ? (
-        <SearchResults query={query} />
-      ) : (
-        <BrowseSongs page={page} />
-      )}
+      {query ? <SearchResults query={query} /> : <BrowseSongs />}
     </div>
   );
 }
@@ -66,44 +62,10 @@ async function SearchResults({ query }: { query: string }) {
   );
 }
 
-async function BrowseSongs({ page }: { page: number }) {
-  const { songs, total } = await getSongsPage(page, PAGE_SIZE);
-  const totalPages = Math.max(1, Math.ceil(total / PAGE_SIZE));
+async function BrowseSongs() {
+  const { songs, total } = await getSongsPage(1, PAGE_SIZE);
 
   return (
-    <div>
-      <SongList songs={songs} />
-      {total > PAGE_SIZE && (
-        <div className="flex items-center justify-between mt-8">
-          <Button
-            asChild={page > 1}
-            variant="outline"
-            size="sm"
-            disabled={page <= 1}
-          >
-            {page > 1 ? (
-              <Link href={`/songs?page=${page - 1}`}>Previous</Link>
-            ) : (
-              <span>Previous</span>
-            )}
-          </Button>
-          <span className="text-sm text-muted-foreground">
-            Page {page} of {totalPages}
-          </span>
-          <Button
-            asChild={page < totalPages}
-            variant="outline"
-            size="sm"
-            disabled={page >= totalPages}
-          >
-            {page < totalPages ? (
-              <Link href={`/songs?page=${page + 1}`}>Next</Link>
-            ) : (
-              <span>Next</span>
-            )}
-          </Button>
-        </div>
-      )}
-    </div>
+    <SongsInfinite initialSongs={songs} total={total} pageSize={PAGE_SIZE} />
   );
 }

--- a/app/(dashboard)/videos/actions.ts
+++ b/app/(dashboard)/videos/actions.ts
@@ -1,0 +1,9 @@
+"use server";
+
+import { getVideosPage } from "@/lib/api";
+
+// Read action used by the videos infinite-scroll grid to fetch the next page
+// from a Client Component.
+export async function fetchVideosPage(page: number, pageSize: number) {
+  return getVideosPage(page, pageSize);
+}

--- a/app/(dashboard)/videos/page.tsx
+++ b/app/(dashboard)/videos/page.tsx
@@ -1,10 +1,10 @@
-import { getRecentVideos } from "@/lib/api";
-import { VideoEmbed } from "@/components/video-embed";
-import { Badge } from "@/components/ui/badge";
-import Link from "next/link";
+import { getVideosPage } from "@/lib/api";
+import { VideosInfinite } from "@/components/videos-infinite";
+
+const PAGE_SIZE = 24;
 
 export default async function VideosPage() {
-  const videos = await getRecentVideos();
+  const { videos, total } = await getVideosPage(1, PAGE_SIZE);
 
   return (
     <div className="container py-10">
@@ -13,27 +13,11 @@ export default async function VideosPage() {
       {videos.length === 0 ? (
         <p className="text-muted-foreground">No videos have been added yet.</p>
       ) : (
-        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
-          {videos.map((video) => (
-            <div key={video.id} className="space-y-2">
-              <VideoEmbed
-                platform={video.platform}
-                videoId={video.video_id}
-                title={video.name}
-              />
-              <div className="flex items-center justify-between gap-2">
-                <p className="font-medium">{video.name}</p>
-                <Badge variant="secondary">{video.type}</Badge>
-              </div>
-              <Link
-                href={`/songs/${video.song.slug}`}
-                className="text-sm text-muted-foreground hover:underline"
-              >
-                {video.song.song}
-              </Link>
-            </div>
-          ))}
-        </div>
+        <VideosInfinite
+          initialVideos={videos}
+          total={total}
+          pageSize={PAGE_SIZE}
+        />
       )}
     </div>
   );

--- a/components/dashboard-shell.tsx
+++ b/components/dashboard-shell.tsx
@@ -27,13 +27,14 @@ import Link from "next/link";
 import { SearchBar } from "@/components/search-bar";
 import { DashboardHeader } from "@/components/dashboard-header";
 import { waitlistDisabled } from "@/flags";
+import { cn } from "@/lib/utils";
 
 const items = [
-  { title: "Songs", url: "/songs", icon: Music },
-  { title: "Tabs", url: "/tabs", icon: BookOpen },
-  { title: "Videos", url: "/videos", icon: Video },
-  { title: "Favorites", url: "/favorites", icon: Heart },
-  { title: "Setlists", url: "/setlists", icon: List },
+  { title: "Songs", url: "/songs", icon: Music, color: "text-purple-600" },
+  { title: "Tabs", url: "/tabs", icon: BookOpen, color: "text-blue-500" },
+  { title: "Videos", url: "/videos", icon: Video, color: "text-orange-500" },
+  { title: "Favorites", url: "/favorites", icon: Heart, color: "text-rose-500" },
+  { title: "Setlists", url: "/setlists", icon: List, color: "text-emerald-500" },
 ];
 
 export async function DashboardShell({ children }: { children: ReactNode }) {
@@ -52,13 +53,15 @@ export async function DashboardShell({ children }: { children: ReactNode }) {
           <SearchBar shadow={false} />
           <SidebarGroup>
             <SidebarGroupContent>
-              <SidebarMenu>
+              <SidebarMenu className="gap-1.5">
                 {items.map((item) => (
                   <SidebarMenuItem key={item.title}>
-                    <SidebarMenuButton asChild>
+                    <SidebarMenuButton asChild size="lg">
                       <a href={item.url}>
-                        <item.icon />
-                        <span>{item.title}</span>
+                        <item.icon className={cn("!size-6", item.color)} />
+                        <span className="text-base font-medium">
+                          {item.title}
+                        </span>
                       </a>
                     </SidebarMenuButton>
                   </SidebarMenuItem>

--- a/components/songs-infinite.tsx
+++ b/components/songs-infinite.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
+import { SongList } from "@/components/song-list";
+import type { SongCard } from "@/lib/api";
+import { fetchSongsPage } from "@/app/(dashboard)/songs/actions";
+
+export function SongsInfinite({
+  initialSongs,
+  total,
+  pageSize,
+}: {
+  initialSongs: SongCard[];
+  total: number;
+  pageSize: number;
+}) {
+  const [songs, setSongs] = useState<SongCard[]>(initialSongs);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const hasMore = songs.length < total;
+
+  const loadMore = useCallback(async () => {
+    if (loading || !hasMore) return;
+    setLoading(true);
+    try {
+      const next = page + 1;
+      const { songs: more } = await fetchSongsPage(next, pageSize);
+      setSongs((prev) => [...prev, ...more]);
+      setPage(next);
+    } finally {
+      setLoading(false);
+    }
+  }, [loading, hasMore, page, pageSize]);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: "200px" }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
+  return (
+    <div>
+      <SongList songs={songs} />
+      {hasMore && (
+        <div ref={sentinelRef} className="flex justify-center py-8">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/videos-infinite.tsx
+++ b/components/videos-infinite.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Loader2 } from "lucide-react";
+import Link from "next/link";
+import { VideoEmbed } from "@/components/video-embed";
+import { Badge } from "@/components/ui/badge";
+import type { RecentVideo } from "@/lib/api";
+import { fetchVideosPage } from "@/app/(dashboard)/videos/actions";
+
+export function VideosInfinite({
+  initialVideos,
+  total,
+  pageSize,
+}: {
+  initialVideos: RecentVideo[];
+  total: number;
+  pageSize: number;
+}) {
+  const [videos, setVideos] = useState<RecentVideo[]>(initialVideos);
+  const [page, setPage] = useState(1);
+  const [loading, setLoading] = useState(false);
+  const sentinelRef = useRef<HTMLDivElement | null>(null);
+
+  const hasMore = videos.length < total;
+
+  const loadMore = useCallback(async () => {
+    if (loading || !hasMore) return;
+    setLoading(true);
+    try {
+      const next = page + 1;
+      const { videos: more } = await fetchVideosPage(next, pageSize);
+      setVideos((prev) => [...prev, ...more]);
+      setPage(next);
+    } finally {
+      setLoading(false);
+    }
+  }, [loading, hasMore, page, pageSize]);
+
+  useEffect(() => {
+    const el = sentinelRef.current;
+    if (!el) return;
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (entries[0]?.isIntersecting) loadMore();
+      },
+      { rootMargin: "200px" }
+    );
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [loadMore]);
+
+  return (
+    <div>
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {videos.map((video) => (
+          <div key={video.id} className="space-y-2">
+            <VideoEmbed
+              platform={video.platform}
+              videoId={video.video_id}
+              title={video.name}
+            />
+            <div className="flex items-center justify-between gap-2">
+              <p className="font-medium">{video.name}</p>
+              <Badge variant="secondary">{video.type}</Badge>
+            </div>
+            <Link
+              href={`/songs/${video.song.slug}`}
+              className="text-sm text-muted-foreground hover:underline"
+            >
+              {video.song.song}
+            </Link>
+          </div>
+        ))}
+      </div>
+      {hasMore && (
+        <div ref={sentinelRef} className="flex justify-center py-8">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -261,6 +261,32 @@ export async function getRecentVideos(limit = 50): Promise<RecentVideo[]> {
   return (data ?? []) as unknown as RecentVideo[];
 }
 
+export async function getVideosPage(page = 1, pageSize = 24) {
+  const supabase = await createClient();
+  const from = (page - 1) * pageSize;
+  const to = from + pageSize - 1;
+  const {
+    data,
+    count,
+    error,
+  } = await supabase
+    .from("videos")
+    .select(
+      `
+      *,
+      song:songs!song_id (song, slug)
+    `,
+      { count: "exact" }
+    )
+    .order("created_at", { ascending: false })
+    .range(from, to);
+  if (error) throw error;
+  return {
+    videos: (data ?? []) as unknown as RecentVideo[],
+    total: count ?? 0,
+  };
+}
+
 export type PerformTab = {
   id: string;
   type: string;


### PR DESCRIPTION
- Color-code dashboard sidebar nav icons and bump icon/text size for
  better mobile legibility (lg buttons, size-6 icons, text-base labels)
- Replace paginated songs browse with intersection-observer infinite
  scroll backed by a fetchSongsPage server action
- Add getVideosPage + fetchVideosPage and convert the videos grid to
  lazy-loading infinite scroll