### PR TITLE
Color-code tab type pills and refine tab selector layout

### DIFF
--- a/components/dashboard-home.tsx
+++ b/components/dashboard-home.tsx
@@ -11,6 +11,7 @@ import {
 import { DashboardShell } from "@/components/dashboard-shell";
 import { SearchBar } from "@/components/search-bar";
 import { Button } from "@/components/ui/button";
+import { TabTypeBadge } from "@/components/tab-type-badge";
 import {
   getRecentTabs,
   getSetlists,
@@ -111,9 +112,9 @@ export default async function DashboardHome() {
                 >
                   <div className="min-w-0">
                     <p className="truncate font-medium">{tab.song.song}</p>
-                    <p className="text-xs capitalize text-muted-foreground">
-                      {tab.type}
-                    </p>
+                    <div className="mt-1">
+                      <TabTypeBadge type={tab.type} />
+                    </div>
                   </div>
                   <Heart className="h-4 w-4 shrink-0 fill-rose-500 text-rose-500" />
                 </Link>
@@ -145,10 +146,12 @@ export default async function DashboardHome() {
                   className="rounded-lg border bg-card p-3 transition-colors hover:border-primary"
                 >
                   <p className="truncate font-medium">{tab.song.song}</p>
-                  <p className="text-xs text-muted-foreground">
-                    <span className="capitalize">{tab.type}</span> · by{" "}
-                    {tab.user?.username ?? "Unknown"}
-                  </p>
+                  <div className="mt-1 flex items-center gap-2">
+                    <TabTypeBadge type={tab.type} />
+                    <span className="truncate text-xs text-muted-foreground">
+                      by {tab.user?.username ?? "Unknown"}
+                    </span>
+                  </div>
                 </Link>
               ))}
             </div>

--- a/components/tab-selector.tsx
+++ b/components/tab-selector.tsx
@@ -16,6 +16,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
+import { TabTypeBadge } from "@/components/tab-type-badge";
 import { Star } from "lucide-react";
 
 export function TabSelector({
@@ -62,14 +63,28 @@ export function TabSelector({
 
   const tabOptions = sortedTabs.map((tab) => ({
     value: tab.id,
-    label:
-      `${tab.name} (${tab.type}) ${tab.favorites ? `★${tab.favorites}` : ""}`.trim(),
-    icon: userFavoriteTabIds.includes(tab.id) ? (
-      <Star className="text-yellow-500 w-4 h-4" />
-    ) : undefined,
+    name: tab.name,
+    type: tab.type,
+    favorites: tab.favorites,
+    isFavorite: userFavoriteTabIds.includes(tab.id),
   }));
 
   const selected = tabOptions.find((o) => o.value === selectedTabId);
+
+  // Color-coded type pill on the left, author smaller in gray next to it.
+  const renderOptionContent = (option: (typeof tabOptions)[number]) => (
+    <span className="flex min-w-0 items-center gap-2">
+      <TabTypeBadge type={option.type} />
+      <span className="truncate text-sm text-muted-foreground">
+        {option.name}
+      </span>
+      {option.favorites > 0 && (
+        <span className="shrink-0 text-xs text-muted-foreground">
+          ★{option.favorites}
+        </span>
+      )}
+    </span>
+  );
 
   const ComboList = (
     <Command>
@@ -81,15 +96,18 @@ export function TabSelector({
             <CommandItem
               key={option.value}
               value={option.value}
+              keywords={[option.name, option.type]}
               onSelect={() => {
                 setSelectedTabId(option.value);
                 setOpen(false);
               }}
             >
-              {option.icon}
-              {option.label}
+              {option.isFavorite && (
+                <Star className="mr-1 h-4 w-4 shrink-0 text-yellow-500" />
+              )}
+              {renderOptionContent(option)}
               {option.value === selectedTabId && (
-                <Star className="w-4 h-4 ml-auto text-purple-600" />
+                <Star className="ml-auto h-4 w-4 shrink-0 text-purple-600" />
               )}
             </CommandItem>
           ))}
@@ -103,10 +121,16 @@ export function TabSelector({
       <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger asChild>
           <Button variant="outline" className="w-full justify-between">
-            <span className="flex items-center gap-2">
-              {selected?.icon}
-              {selected ? selected.label : <>Select a tab...</>}
-            </span>
+            {selected ? (
+              <span className="flex min-w-0 items-center gap-2">
+                {selected.isFavorite && (
+                  <Star className="h-4 w-4 shrink-0 text-yellow-500" />
+                )}
+                {renderOptionContent(selected)}
+              </span>
+            ) : (
+              <span>Select a tab...</span>
+            )}
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-[300px] p-0" align="start">
@@ -120,10 +144,16 @@ export function TabSelector({
     <Drawer open={open} onOpenChange={setOpen}>
       <DrawerTrigger asChild>
         <Button variant="outline" className="w-full justify-between">
-          <span className="flex items-center gap-2">
-            {selected?.icon}
-            {selected ? selected.label : <>Select a tab...</>}
-          </span>
+          {selected ? (
+            <span className="flex min-w-0 items-center gap-2">
+              {selected.isFavorite && (
+                <Star className="h-4 w-4 shrink-0 text-yellow-500" />
+              )}
+              {renderOptionContent(selected)}
+            </span>
+          ) : (
+            <span>Select a tab...</span>
+          )}
         </Button>
       </DrawerTrigger>
       <DrawerContent>

--- a/components/tab-type-badge.tsx
+++ b/components/tab-type-badge.tsx
@@ -1,0 +1,47 @@
+import * as React from "react";
+import { cn } from "@/lib/utils";
+import type { TabType } from "@/types";
+
+// Color-coded styles per tab type (light + dark mode).
+const TAB_TYPE_STYLES: Record<TabType, string> = {
+  tab: "bg-blue-100 text-blue-800 dark:bg-blue-950 dark:text-blue-300",
+  chords:
+    "bg-emerald-100 text-emerald-800 dark:bg-emerald-950 dark:text-emerald-300",
+  vextab:
+    "bg-purple-100 text-purple-800 dark:bg-purple-950 dark:text-purple-300",
+};
+
+const TAB_TYPE_LABELS: Record<TabType, string> = {
+  tab: "Tab",
+  chords: "Chords",
+  vextab: "VexTab",
+};
+
+function isTabType(value: string): value is TabType {
+  return value === "tab" || value === "chords" || value === "vextab";
+}
+
+export function TabTypeBadge({
+  type,
+  className,
+}: {
+  type: string;
+  className?: string;
+}) {
+  const style = isTabType(type)
+    ? TAB_TYPE_STYLES[type]
+    : "bg-secondary text-secondary-foreground";
+  const label = isTabType(type) ? TAB_TYPE_LABELS[type] : type;
+
+  return (
+    <span
+      className={cn(
+        "inline-flex shrink-0 items-center rounded-full border border-transparent px-2 py-0.5 text-xs font-semibold",
+        style,
+        className,
+      )}
+    >
+      {label}
+    </span>
+  );
+}

--- a/components/tab-viewer.tsx
+++ b/components/tab-viewer.tsx
@@ -14,6 +14,7 @@ import {
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { VextabRenderer } from "@/components/vextab-renderer";
+import { TabTypeBadge } from "@/components/tab-type-badge";
 import { cn } from "@/lib/utils";
 import { transposeChordSheet, formatSemitones } from "@/lib/chords";
 
@@ -297,9 +298,9 @@ export function TabViewer({ tab, title, fill = false }: TabViewerProps) {
             {title && (
               <p className="truncate text-sm font-semibold">{title}</p>
             )}
-            <p className="text-xs capitalize text-muted-foreground">
-              {tab.type}
-            </p>
+            <div className="mt-1">
+              <TabTypeBadge type={tab.type} />
+            </div>
           </div>
           {controls}
         </div>


### PR DESCRIPTION
Add a reusable TabTypeBadge that renders tab/chords/vextab as
color-coded pills (blue/emerald/purple, light + dark). Use it in the
song-page tab selector so each option leads with the colored type pill
followed by the author in smaller gray text, and apply it consistently
on the dashboard and tab viewer.