### PR TITLE
Reorganize tab controls into a single, clearer toolbar

### DIFF
--- a/app/(dashboard)/songs/[slug]/page.tsx
+++ b/app/(dashboard)/songs/[slug]/page.tsx
@@ -82,20 +82,16 @@ export default async function SongPage({
               )}
             </EmptyState>
           ) : (
-            <>
-              {isAuthed && (
-                <div className="flex justify-end mb-4">
-                  <AddTabDialog songId={song.id} slug={slug} />
-                </div>
-              )}
-              <TabSection
-                tabs={tabs}
-                userFavoriteTabIds={userFavoriteTabIds}
-                canFavorite={isAuthed}
-                currentUserId={user?.id}
-                revalidate={revalidatePath}
-              />
-            </>
+            <TabSection
+              tabs={tabs}
+              userFavoriteTabIds={userFavoriteTabIds}
+              canFavorite={isAuthed}
+              canAddTab={isAuthed}
+              currentUserId={user?.id}
+              songId={song.id}
+              slug={slug}
+              revalidate={revalidatePath}
+            />
           )}
         </TabsContent>
         <TabsContent value="videos">

--- a/components/add-tab-dialog.tsx
+++ b/components/add-tab-dialog.tsx
@@ -15,16 +15,18 @@ import { Plus } from "lucide-react";
 export function AddTabDialog({
   songId,
   slug,
+  variant = "default",
 }: {
   songId: string;
   slug: string;
+  variant?: "default" | "outline";
 }) {
   const [open, setOpen] = React.useState(false);
 
   return (
     <Dialog open={open} onOpenChange={setOpen}>
       <DialogTrigger asChild>
-        <Button size="sm">
+        <Button size="sm" variant={variant}>
           <Plus className="h-4 w-4 mr-1" /> Add tab
         </Button>
       </DialogTrigger>

--- a/components/tab-section.tsx
+++ b/components/tab-section.tsx
@@ -5,12 +5,16 @@ import { TabViewer } from "@/components/tab-viewer";
 import { FavoriteButton } from "@/components/favorite-button";
 import { EditTabDialog } from "@/components/edit-tab-dialog";
 import { ReportDialog } from "@/components/report-dialog";
+import { AddTabDialog } from "@/components/add-tab-dialog";
 
 export function TabSection({
   tabs,
   userFavoriteTabIds = [],
   canFavorite = false,
+  canAddTab = false,
   currentUserId,
+  songId,
+  slug,
   revalidate,
 }: {
   tabs: Array<{
@@ -23,7 +27,10 @@ export function TabSection({
   }>;
   userFavoriteTabIds?: string[];
   canFavorite?: boolean;
+  canAddTab?: boolean;
   currentUserId?: string;
+  songId?: string;
+  slug?: string;
   revalidate?: string;
 }) {
   const [selectedTabId, setSelectedTabId] = React.useState<string | undefined>(
@@ -41,8 +48,10 @@ export function TabSection({
 
   return (
     <div>
-      <div className="flex items-center gap-2 mb-4">
-        <div className="flex-1">
+      {/* One toolbar: "which tab" on the left, actions on the selected tab
+          (plus the secondary "add tab") grouped together on the right. */}
+      <div className="flex flex-wrap items-center gap-2 mb-4">
+        <div className="min-w-0 flex-1">
           <TabSelector
             tabs={tabs.map((tab) => ({
               id: tab.id,
@@ -54,23 +63,28 @@ export function TabSection({
             onSelect={setSelectedTabId}
           />
         </div>
-        {canFavorite && selectedTab && (
-          <FavoriteButton
-            tabId={selectedTab.id}
-            initialFavorited={userFavoriteTabIds.includes(selectedTab.id)}
-            initialCount={selectedTab.favorites}
-            revalidate={revalidate}
-          />
-        )}
-        {selectedTab && currentUserId === selectedTab.author_id && (
-          <EditTabDialog tab={selectedTab} revalidate={revalidate} />
-        )}
-        {/* Signed-in users (who aren't the author) can flag a tab. */}
-        {canFavorite &&
-          selectedTab &&
-          currentUserId !== selectedTab.author_id && (
-            <ReportDialog tabId={selectedTab.id} />
+        <div className="flex items-center gap-1.5">
+          {canFavorite && selectedTab && (
+            <FavoriteButton
+              tabId={selectedTab.id}
+              initialFavorited={userFavoriteTabIds.includes(selectedTab.id)}
+              initialCount={selectedTab.favorites}
+              revalidate={revalidate}
+            />
           )}
+          {selectedTab && currentUserId === selectedTab.author_id && (
+            <EditTabDialog tab={selectedTab} revalidate={revalidate} />
+          )}
+          {/* Signed-in users (who aren't the author) can flag a tab. */}
+          {canFavorite &&
+            selectedTab &&
+            currentUserId !== selectedTab.author_id && (
+              <ReportDialog tabId={selectedTab.id} />
+            )}
+          {canAddTab && songId && slug && (
+            <AddTabDialog songId={songId} slug={slug} variant="outline" />
+          )}
+        </div>
       </div>
       <TabViewer tab={selectedTab} />
     </div>

--- a/components/tab-selector.tsx
+++ b/components/tab-selector.tsx
@@ -17,7 +17,7 @@ import {
   PopoverTrigger,
 } from "@/components/ui/popover";
 import { TabTypeBadge } from "@/components/tab-type-badge";
-import { Star } from "lucide-react";
+import { ChevronsUpDown, Star } from "lucide-react";
 
 export function TabSelector({
   tabs,
@@ -71,12 +71,24 @@ export function TabSelector({
 
   const selected = tabOptions.find((o) => o.value === selectedTabId);
 
-  // Color-coded type pill on the left, author smaller in gray next to it.
-  const renderOptionContent = (option: (typeof tabOptions)[number]) => (
+  // Color-coded type pill, then the author ("by …"), then favorite count.
+  const renderAttribution = (
+    option: (typeof tabOptions)[number],
+    { emphasizeAuthor = false }: { emphasizeAuthor?: boolean } = {}
+  ) => (
     <span className="flex min-w-0 items-center gap-2">
+      {option.isFavorite && (
+        <Star className="h-4 w-4 shrink-0 text-yellow-500" />
+      )}
       <TabTypeBadge type={option.type} />
-      <span className="truncate text-sm text-muted-foreground">
-        {option.name}
+      <span
+        className={
+          emphasizeAuthor
+            ? "truncate text-sm"
+            : "truncate text-sm text-muted-foreground"
+        }
+      >
+        by {option.name}
       </span>
       {option.favorites > 0 && (
         <span className="shrink-0 text-xs text-muted-foreground">
@@ -86,9 +98,32 @@ export function TabSelector({
     </span>
   );
 
+  // Only one tab — there's nothing to switch between, so show a plain
+  // attribution line instead of a dropdown that implies a choice.
+  if (tabOptions.length <= 1) {
+    const only = tabOptions[0];
+    if (!only) return null;
+    return (
+      <div className="flex h-9 items-center px-1">
+        {renderAttribution(only)}
+      </div>
+    );
+  }
+
+  const triggerButton = (
+    <Button variant="outline" className="w-full justify-between">
+      {selected ? (
+        renderAttribution(selected, { emphasizeAuthor: true })
+      ) : (
+        <span className="text-muted-foreground">Select a tab…</span>
+      )}
+      <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+    </Button>
+  );
+
   const ComboList = (
     <Command>
-      <CommandInput placeholder="Filter tabs..." />
+      <CommandInput placeholder="Filter tabs by author…" />
       <CommandList>
         <CommandEmpty>No tabs found.</CommandEmpty>
         <CommandGroup>
@@ -102,10 +137,7 @@ export function TabSelector({
                 setOpen(false);
               }}
             >
-              {option.isFavorite && (
-                <Star className="mr-1 h-4 w-4 shrink-0 text-yellow-500" />
-              )}
-              {renderOptionContent(option)}
+              {renderAttribution(option)}
               {option.value === selectedTabId && (
                 <Star className="ml-auto h-4 w-4 shrink-0 text-purple-600" />
               )}
@@ -119,20 +151,7 @@ export function TabSelector({
   if (!isMobile) {
     return (
       <Popover open={open} onOpenChange={setOpen}>
-        <PopoverTrigger asChild>
-          <Button variant="outline" className="w-full justify-between">
-            {selected ? (
-              <span className="flex min-w-0 items-center gap-2">
-                {selected.isFavorite && (
-                  <Star className="h-4 w-4 shrink-0 text-yellow-500" />
-                )}
-                {renderOptionContent(selected)}
-              </span>
-            ) : (
-              <span>Select a tab...</span>
-            )}
-          </Button>
-        </PopoverTrigger>
+        <PopoverTrigger asChild>{triggerButton}</PopoverTrigger>
         <PopoverContent className="w-[300px] p-0" align="start">
           {ComboList}
         </PopoverContent>
@@ -142,20 +161,7 @@ export function TabSelector({
 
   return (
     <Drawer open={open} onOpenChange={setOpen}>
-      <DrawerTrigger asChild>
-        <Button variant="outline" className="w-full justify-between">
-          {selected ? (
-            <span className="flex min-w-0 items-center gap-2">
-              {selected.isFavorite && (
-                <Star className="h-4 w-4 shrink-0 text-yellow-500" />
-              )}
-              {renderOptionContent(selected)}
-            </span>
-          ) : (
-            <span>Select a tab...</span>
-          )}
-        </Button>
-      </DrawerTrigger>
+      <DrawerTrigger asChild>{triggerButton}</DrawerTrigger>
       <DrawerContent>
         <div className="mt-4 border-t">{ComboList}</div>
       </DrawerContent>


### PR DESCRIPTION
- Group the tab selector (left) with per-tab actions and Add tab (right)
  into one toolbar row instead of stacking three control rows.
- Demote Add tab from a primary button to a secondary outline button so it
  no longer visually outweighs the tab content; keep it primary in the
  empty state via a new variant prop.
- Make the selector author-based ('by <author>') with a chevron affordance,
  and render a plain attribution line instead of a dropdown when there is
  only one tab (no fake choice).