### PR TITLE
Add private-beta allowlist gate, FAQ page, and bug-report links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,64 @@
+name: "🐛 Bug report"
+description: Something in the Phishub beta isn't working the way you expected.
+title: "[Bug]: "
+labels: ["bug", "beta"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping test Phishub! Please fill out as much as you can —
+        it makes bugs much faster to track down.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: A clear description of the bug.
+      placeholder: When I added a tab to "Sand", the page showed an error instead of saving.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: How can we make it happen again?
+      placeholder: |
+        1. Go to the song page for ...
+        2. Click ...
+        3. See error
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: What did you expect to happen?
+    validations:
+      required: false
+  - type: dropdown
+    id: area
+    attributes:
+      label: Where in the app?
+      options:
+        - Tabs / chords
+        - Songs
+        - Videos
+        - Setlists
+        - Favorites
+        - Comments
+        - Sign in / sign up / profile
+        - Other / not sure
+    validations:
+      required: false
+  - type: input
+    id: device
+    attributes:
+      label: Device & browser
+      placeholder: iPhone 15, Safari · or · Windows, Chrome
+    validations:
+      required: false
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots
+      description: Drag and drop any screenshots here (optional).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: ❓ Questions & general help
+    url: https://phishub.com/faq
+    about: Check the FAQ for how the private beta works and how to contribute.
+  - name: 📧 Email us
+    about: For anything you'd rather not post publicly, email hello@phishub.com.
+    url: mailto:hello@phishub.com

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,24 @@
+name: "💡 Feature request / idea"
+description: Suggest an improvement or a new capability for Phishub.
+title: "[Idea]: "
+labels: ["enhancement", "beta"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Got an idea to make Phishub better for the Phish community? We'd love to
+        hear it.
+  - type: textarea
+    id: idea
+    attributes:
+      label: What's the idea?
+      description: Describe the feature or improvement you'd like to see.
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: What problem does it solve?
+      description: What are you trying to do that's hard or impossible today?
+    validations:
+      required: false

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,8 +158,15 @@ Core tables (RLS enabled on all; public `SELECT`, authenticated/owner writes):
 | `favorites` | Links users to tabs; counts aggregated in `getTabsBySongId`. |
 | `profiles` | `user_id`→auth.users PK, unique `username`, `avatar_url`, `country/state/city`. Required before accessing the app. |
 | `waitlist` | `email` (unique), `source`, `referrer_url`. |
+| `beta_allowlist` | Private-beta gate. `email` (PK, lowercased), `note`, `invited_at`. RLS lets a signed-in user read **only their own** row. Add invitee emails out-of-band (dashboard/SQL) before sending sign-up links. |
 
 `updated_at` columns are maintained by the `update_updated_at_column()` trigger.
+
+> 🔒 **Private-beta access gate:** `middleware.ts` redirects any authenticated
+> user whose email is **not** in `beta_allowlist` to `/pending`. The
+> `waitlistDisabled` flag only toggles landing-page UI — it does **not** gate
+> access. So a real private beta = keep the flag `false` (public sees the
+> waitlist) and admit people by adding their email to `beta_allowlist`.
 
 > ⚠️ **Schema history to be aware of:** the `songs` table was migrated from an
 > original shape (`title`, `composer`, `debut_date`, `history`) to the phish.net

--- a/app/faq/page.tsx
+++ b/app/faq/page.tsx
@@ -1,0 +1,141 @@
+import Link from "next/link";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft, Bug } from "lucide-react";
+
+// Public GitHub repo used for beta bug/feature tracking. Update if the repo
+// moves.
+const GITHUB_ISSUES_URL = "https://github.com/mplunket/phishub/issues/new/choose";
+
+// Where beta questions should go. Keep in sync with the contact address used in
+// the Terms of Use.
+const CONTACT_EMAIL = "hello@phishub.com";
+
+export const metadata = {
+  title: "FAQ - Phishub",
+  description:
+    "Frequently asked questions about Phishub, the private beta, contributing tabs, and reporting bugs.",
+};
+
+export default function FaqPage() {
+  return (
+    <div className="container max-w-3xl py-10">
+      <Button asChild variant="ghost" size="sm" className="mb-4 -ml-2">
+        <Link href="/">
+          <ArrowLeft className="mr-1 h-4 w-4" /> Home
+        </Link>
+      </Button>
+
+      <h1 className="text-3xl font-bold sm:text-4xl">Frequently asked questions</h1>
+      <p className="mt-2 text-muted-foreground">
+        Everything you need to know about the Phishub private beta.
+      </p>
+
+      <div className="prose mt-8 max-w-none space-y-8 text-sm leading-relaxed">
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">What is Phishub?</h2>
+          <p>
+            Phishub is a community platform for Phish music education — guitar
+            tabs, chord charts, video lessons, setlists, and discussion, built
+            on top of a complete catalog of every Phish song. It&apos;s an
+            independent, fan-run project and is not affiliated with or endorsed
+            by the band.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            What does &ldquo;private beta&rdquo; mean?
+          </h2>
+          <p>
+            We&apos;re opening Phishub to a small group of contributors first so
+            we can grow the tab and chord library and smooth out rough edges
+            before a wider launch. Access is invite-only right now: if you
+            signed up and landed on the &ldquo;you&apos;re on the list&rdquo;
+            page, your spot is reserved and we&apos;ll email you when your
+            account is approved.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">How do I get in?</h2>
+          <p>
+            Beta access is granted by invitation. If you were invited, sign up
+            using the same email address your invite was sent to — that&apos;s
+            how we match your account to your spot. If you joined the waitlist
+            on the homepage, you&apos;re in the queue and we&apos;ll reach out as
+            we add more contributors.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            How do I contribute a tab or chord chart?
+          </h2>
+          <p>
+            Once you&apos;re in, find a song and add your tab, chords, or a video
+            lesson right from the song&apos;s page. The catalog already has every
+            Phish song, so you can jump straight to filling in the parts you
+            know. The more you share, the more useful Phishub gets for everyone.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            What can I post? (Please read)
+          </h2>
+          <p>
+            Tabs you contribute must be <strong>your own original
+            transcription</strong> — your interpretation of how to play the song
+            — not a copy of someone else&apos;s published tablature or
+            copyrighted sheet music. Don&apos;t upload scanned, photographed, or
+            copied official sheet music or publisher arrangements. See the{" "}
+            <Link
+              href="/content-policy"
+              className="font-medium underline hover:text-foreground"
+            >
+              Content &amp; Copyright Policy
+            </Link>{" "}
+            and{" "}
+            <Link
+              href="/terms"
+              className="font-medium underline hover:text-foreground"
+            >
+              Terms of Use
+            </Link>{" "}
+            for the full details.
+          </p>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">
+            I found a bug / have a feature idea. Where does it go?
+          </h2>
+          <p>
+            During the beta we track bugs and feature requests on our public
+            GitHub repository. Filing an issue is the fastest way to make sure
+            it gets seen and tracked. You&apos;ll need a free GitHub account.
+          </p>
+          <Button asChild className="not-prose bg-purple-600 hover:bg-purple-700">
+            <a href={GITHUB_ISSUES_URL} target="_blank" rel="noopener noreferrer">
+              <Bug className="mr-2 h-4 w-4" /> Report a bug or request a feature
+            </a>
+          </Button>
+        </section>
+
+        <section className="space-y-2">
+          <h2 className="text-xl font-semibold">Still have questions?</h2>
+          <p>
+            Email{" "}
+            <a
+              href={`mailto:${CONTACT_EMAIL}`}
+              className="font-medium underline hover:text-foreground"
+            >
+              {CONTACT_EMAIL}
+            </a>{" "}
+            and we&apos;ll get back to you.
+          </p>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/app/pending/page.tsx
+++ b/app/pending/page.tsx
@@ -1,0 +1,50 @@
+import Link from "next/link";
+import { Guitar, Mail } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { signOutAction } from "@/app/actions";
+
+export const metadata = {
+  title: "You're on the list - Phishub",
+  description:
+    "Phishub is currently in private beta. Your account is on the waitlist.",
+};
+
+// Landing spot for authenticated users who are not yet on the beta allowlist.
+// The middleware redirects them here instead of into the app.
+export default function PendingPage() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-gradient-to-br from-purple-50 via-white to-orange-50 px-4">
+      <div className="w-full max-w-md rounded-2xl bg-white/90 p-8 text-center shadow-xl">
+        <Link href="/" className="mb-6 flex items-center justify-center">
+          <Guitar className="h-9 w-9 text-purple-600" />
+          <span className="ml-2 text-2xl font-bold bg-gradient-to-r from-purple-600 to-orange-500 bg-clip-text text-transparent">
+            Phishub
+          </span>
+        </Link>
+
+        <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-purple-100">
+          <Mail className="h-6 w-6 text-purple-600" />
+        </div>
+
+        <h1 className="text-2xl font-bold">You&apos;re on the list 🎸</h1>
+        <p className="mt-3 text-sm leading-relaxed text-gray-600">
+          Thanks for signing up! Phishub is in a small private beta right now
+          while we build out the tab and chord library with our first
+          contributors. We&apos;ll email you as soon as your account is approved
+          and you can dive in.
+        </p>
+        <p className="mt-3 text-sm leading-relaxed text-gray-600">
+          If you were expecting access already, give it a minute and refresh —
+          and make sure you signed in with the same email you were invited
+          with.
+        </p>
+
+        <form action={signOutAction} className="mt-6">
+          <Button type="submit" variant="outline" className="w-full">
+            Sign out
+          </Button>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/components/dashboard-shell.tsx
+++ b/components/dashboard-shell.tsx
@@ -1,21 +1,19 @@
 import { ReactNode } from "react";
 import {
   Music,
-  Users,
   Heart,
   List,
-  Upload,
-  MessageCircle,
-  Share2,
   Guitar,
-  Star,
   BookOpen,
   Video,
+  HelpCircle,
+  Bug,
 } from "lucide-react";
 import {
   Sidebar,
   SidebarProvider,
   SidebarContent,
+  SidebarFooter,
   SidebarGroup,
   SidebarGroupContent,
   SidebarMenu,
@@ -36,6 +34,11 @@ const items = [
   { title: "Favorites", url: "/favorites", icon: Heart, color: "text-rose-500" },
   { title: "Setlists", url: "/setlists", icon: List, color: "text-emerald-500" },
 ];
+
+// Public GitHub repo used for beta bug/feature tracking. Keep in sync with the
+// link on the FAQ page.
+const GITHUB_ISSUES_URL =
+  "https://github.com/mplunket/phishub/issues/new/choose";
 
 export async function DashboardShell({ children }: { children: ReactNode }) {
   const waitlist = await waitlistDisabled();
@@ -70,6 +73,30 @@ export async function DashboardShell({ children }: { children: ReactNode }) {
             </SidebarGroupContent>
           </SidebarGroup>
         </SidebarContent>
+        <SidebarFooter>
+          <SidebarMenu className="gap-1">
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild>
+                <Link href="/faq">
+                  <HelpCircle className="!size-5 text-gray-500" />
+                  <span className="text-sm font-medium">FAQ</span>
+                </Link>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            <SidebarMenuItem>
+              <SidebarMenuButton asChild>
+                <a
+                  href={GITHUB_ISSUES_URL}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
+                  <Bug className="!size-5 text-gray-500" />
+                  <span className="text-sm font-medium">Report a bug</span>
+                </a>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+          </SidebarMenu>
+        </SidebarFooter>
       </Sidebar>
       <SidebarInset>
         <DashboardHeader hideWaitlist={waitlist} />

--- a/components/landing-page.tsx
+++ b/components/landing-page.tsx
@@ -264,6 +264,12 @@ export default async function LandingPage() {
           <nav className="sm:ml-auto flex gap-4 sm:gap-6">
             <Link
               className="text-xs hover:underline underline-offset-4 text-gray-500"
+              href="/faq"
+            >
+              FAQ
+            </Link>
+            <Link
+              className="text-xs hover:underline underline-offset-4 text-gray-500"
               href="/terms"
             >
               Terms of Use

--- a/supabase/migrations/20260618120000_create_beta_allowlist.sql
+++ b/supabase/migrations/20260618120000_create_beta_allowlist.sql
@@ -1,0 +1,38 @@
+-- Private beta allowlist. During the pilot, the site is publicly visible (the
+-- landing page + waitlist), but only people whose email is listed here may
+-- actually enter the app. The gate is enforced in middleware (see
+-- utils/supabase/middleware.ts): an authenticated user whose email is not in
+-- this table is redirected to /pending instead of the dashboard.
+--
+-- Invites are managed out-of-band (Supabase dashboard / SQL editor / service
+-- role) by adding the invitee's email here BEFORE sending them a sign-up link.
+-- There are intentionally no INSERT/UPDATE/DELETE policies, so end users can
+-- never add themselves.
+
+create table if not exists beta_allowlist (
+    email text primary key,
+    note text,
+    invited_at timestamp with time zone default timezone('utc'::text, now()) not null
+);
+
+-- Store/compare emails lowercased so allowlist checks are case-insensitive and
+-- match however Supabase Auth normalizes the address.
+create or replace function lower_beta_email()
+returns trigger as $$
+begin
+    new.email = lower(new.email);
+    return new;
+end;
+$$ language plpgsql;
+
+create trigger beta_allowlist_lower_email
+    before insert or update on beta_allowlist
+    for each row
+    execute function lower_beta_email();
+
+alter table beta_allowlist enable row level security;
+
+-- A signed-in user may check ONLY whether their own email is allowlisted. This
+-- is the single query the middleware runs; it never exposes the full list.
+create policy "Users can check their own allowlist status" on beta_allowlist
+    for select using (lower(auth.jwt() ->> 'email') = email);

--- a/types/index.ts
+++ b/types/index.ts
@@ -75,6 +75,12 @@ export interface Report {
   created_at: string;
 }
 
+export interface BetaAllowlistEntry {
+  email: string;
+  note: string | null;
+  invited_at: string;
+}
+
 export type VideoType = "lesson" | "performance";
 export type VideoPlatform = "youtube" | "vimeo";
 

--- a/utils/supabase/middleware.ts
+++ b/utils/supabase/middleware.ts
@@ -39,27 +39,51 @@ export const updateSession = async (request: NextRequest) => {
     // https://supabase.com/docs/guides/auth/server-side/nextjs
     const user = await supabase.auth.getUser();
 
-    // Guard: If user is authenticated, check for profile
+    // Guard: If user is authenticated, enforce the private-beta allowlist and
+    // profile completion before letting them into the app.
     if (user.data?.user) {
-      // Only check for profile on protected/dashboard routes (not /create-profile, /sign-in, /sign-up, /api, etc.)
       const path = request.nextUrl.pathname;
-      const isProtected =
-        !path.startsWith("/api") &&
-        !path.startsWith("/auth") &&
-        !path.startsWith("/sign-in") &&
-        !path.startsWith("/sign-up") &&
-        !path.startsWith("/create-profile") &&
-        !path.startsWith("/public") &&
-        !path.startsWith("/_next");
-      if (isProtected) {
-        // Query for profile
-        const { data: profile } = await supabase
-          .from("profiles")
-          .select("user_id")
-          .eq("user_id", user.data.user.id)
-          .single();
-        if (!profile) {
-          return NextResponse.redirect(new URL("/create-profile", request.url));
+      // Routes that an authenticated-but-not-yet-admitted user must still reach
+      // (auth flow, the "you're on the list" page, static assets, etc.).
+      const isOpenPath =
+        path.startsWith("/api") ||
+        path.startsWith("/auth") ||
+        path.startsWith("/sign-in") ||
+        path.startsWith("/sign-up") ||
+        path.startsWith("/pending") ||
+        path.startsWith("/public") ||
+        path.startsWith("/_next");
+
+      if (!isOpenPath) {
+        // Private-beta gate: only allowlisted emails may enter the app. The RLS
+        // policy on beta_allowlist limits this to the user's own email, so this
+        // returns at most their own row.
+        const email = user.data.user.email?.toLowerCase();
+        const { data: allowed } = email
+          ? await supabase
+              .from("beta_allowlist")
+              .select("email")
+              .eq("email", email)
+              .maybeSingle()
+          : { data: null };
+
+        if (!allowed) {
+          return NextResponse.redirect(new URL("/pending", request.url));
+        }
+
+        // Profile completion guard (allowlisted users only). /create-profile is
+        // itself gated by the allowlist above but must not require a profile.
+        if (!path.startsWith("/create-profile")) {
+          const { data: profile } = await supabase
+            .from("profiles")
+            .select("user_id")
+            .eq("user_id", user.data.user.id)
+            .single();
+          if (!profile) {
+            return NextResponse.redirect(
+              new URL("/create-profile", request.url)
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
Set up the private beta launch infrastructure:

- beta_allowlist table (email-keyed, RLS limits a signed-in user to reading
  only their own row) — admit invitees by adding their email out-of-band.
- middleware now redirects authenticated users who aren't allowlisted to a new
  /pending page instead of into the app. The waitlistDisabled flag only
  controls landing-page UI, so this is what actually enforces a private beta.
- /pending page ("you're on the list") with sign-out.
- /faq page covering the beta, contributing tabs, originality/copyright, and
  how to report bugs.
- "Report a bug" + FAQ links in the dashboard sidebar and the landing footer,
  pointing at the public GitHub repo's issue templates.
- GitHub issue templates (bug report + feature request) and chooser config.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MbPcdpBTHrp53XjDHwerLh